### PR TITLE
Bridge change to allow urls + Lua change to add port if missing.

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -48,8 +48,20 @@ local function send_data(data_type, reliable, data)
   M.connection.tcp:send(data)
 end
 
+local function sanitize_addr(addr)
+  -- Trim leading and trailing spaces that might occur during a copy/paste
+  local sanitized = addr:gsub("^%s*(.-)%s*$", "%1")
+  
+  -- Check if port is missing, add default port if so
+  if not sanitized:find(":") then
+    sanitized = sanitized .. ":3698" 
+  end
+  return sanitized
+end
+
 local function connect(addr, player_name)
   print("Connecting...")
+  addr = sanitize_addr(addr)
   kissui.add_message("Connecting to "..addr.."...")
   M.connection.tcp = socket.tcp()
   M.connection.tcp:settimeout(3.0)

--- a/kissmp-bridge/src/main.rs
+++ b/kissmp-bridge/src/main.rs
@@ -1,5 +1,5 @@
 use futures::{StreamExt, TryStreamExt};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
@@ -34,9 +34,10 @@ async fn main() {
         let mut addr_buffer = vec![0; addr_len];
         reader.read_exact(&mut addr_buffer).await.unwrap();
         let addr_str = String::from_utf8(addr_buffer).unwrap();
+
         let addr = {
-            if let Ok(addr) = addr_str.parse::<SocketAddr>() {
-                addr
+            if let Ok(mut socket_addrs) = addr_str.to_socket_addrs() {
+                socket_addrs.next().unwrap()
             }
             else{
                 println!("Failed to parse address!");


### PR DESCRIPTION
Use to_socket_addrs instead of parsing directly as a SocketAddr, which allows connecting through a domain name as well as IP.
Trim input address, and add default port if missing.