### PR TITLE
Fixed Typos

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -210,8 +210,8 @@ local function connect(addr, player_name)
   local connected, err = M.connection.tcp:connect("127.0.0.1", "7894")
 
   -- Send server address to the bridge
-  local addr_lenght = ffi.string(ffi.new("uint32_t[?]", 1, {#addr}), 4)
-  M.connection.tcp:send(addr_lenght)
+  local addr_length = ffi.string(ffi.new("uint32_t[?]", 1, {#addr}), 4)
+  M.connection.tcp:send(addr_length)
   M.connection.tcp:send(addr)
 
   local connection_confirmed = M.connection.tcp:receive(1)

--- a/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
+++ b/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
@@ -39,13 +39,13 @@ local function send_vehicle_meta_updates()
       local id = vehicle:getID()
       
       local color = vehicle.color
-      local palete_0 = vehicle.colorPalette0
-      local palete_1 = vehicle.colorPalette1
+      local palette_0 = vehicle.colorPalette0
+      local palette_1 = vehicle.colorPalette1
       local plate = vehicle.licenseText
       local colors = {
         {color.x, color.y, color.z, color.w},
-        {palete_0.x, palete_0.y, palete_0.z, palete_0.w},
-        {palete_1.x, palete_1.y, palete_1.z, palete_1.w}
+        {palette_0.x, palette_0.y, palette_0.z, palette_0.w},
+        {palette_1.x, palette_1.y, palette_1.z, palette_1.w}
       }
       
       if plates_buffer[id] then
@@ -96,8 +96,8 @@ local function send_vehicle_config_inner(id, parts_config)
   local vehicle = be:getObjectByID(id)
   local parts_config = parts_config
   local color = vehicle.color
-  local palete_0 = vehicle.colorPalette0
-  local palete_1 = vehicle.colorPalette1
+  local palette_0 = vehicle.colorPalette0
+  local palette_1 = vehicle.colorPalette1
   local plate = vehicle.licenseText
   local position = vehicle:getPosition()
   local rotation = vehicle:getRotation()
@@ -106,8 +106,8 @@ local function send_vehicle_config_inner(id, parts_config)
   vehicle_data.parts_config = parts_config
   vehicle_data.in_game_id = id
   vehicle_data.color = {color.x, color.y, color.z, color.w}
-  vehicle_data.palete_0 = {palete_0.x, palete_0.y, palete_0.z, palete_0.w}
-  vehicle_data.palete_1 = {palete_1.x, palete_1.y, palete_1.z, palete_1.w}
+  vehicle_data.palette_0 = {palette_0.x, palette_0.y, palette_0.z, palette_0.w}
+  vehicle_data.palette_1 = {palette_1.x, palette_1.y, palette_1.z, palette_1.w}
   vehicle_data.plate = plate
   vehicle_data.name = vehicle:getJBeamFilename()
   vehicle_data.position = {position.x, position.y, position.z}
@@ -145,8 +145,8 @@ local function spawn_vehicle(data)
   local parts_config = jsonDecode(data.parts_config)
   local c = data.color
   local plate = data.plate
-  local cp0 = data.palete_0
-  local cp1 = data.palete_1
+  local cp0 = data.palette_0
+  local cp1 = data.palette_1
   local name = data.name
   print("Vehicle spawned")
   local spawned = spawn.spawnVehicle(

--- a/kissmp-master/src/main.rs
+++ b/kissmp-master/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
     let mut server_list = ServerList(HashMap::new());
     let mut addresses: HashMap<std::net::IpAddr, HashMap<u16, bool>> = HashMap::new();
 
-    let censor_standart = censor::Censor::Standard;
+    let censor_standard = censor::Censor::Standard;
     let censor_sex = censor::Censor::Sex;
 
     for mut request in server.incoming_requests() {
@@ -51,7 +51,7 @@ fn main() {
                 }
                 server_info.description.truncate(256);
                 server_info.name.truncate(64);
-                if censor_standart.check(&server_info.name) || censor_sex.check(&server_info.name) {
+                if censor_standard.check(&server_info.name) || censor_sex.check(&server_info.name) {
                     continue;
                 }
                 if let Some(ports) = addresses.get_mut(&addr.ip()) {

--- a/kissmp-server/src/events.rs
+++ b/kissmp-server/src/events.rs
@@ -189,8 +189,8 @@ impl Server {
                 {
                     if let Some(vehicle) = self.vehicles.get_mut(&server_id) {
                         vehicle.data.color = meta.colors_table[0];
-                        vehicle.data.palete_0 = meta.colors_table[1];
-                        vehicle.data.palete_1 = meta.colors_table[2];
+                        vehicle.data.palette_0 = meta.colors_table[1];
+                        vehicle.data.palette_1 = meta.colors_table[2];
                         vehicle.data.plate = meta.plate.clone();
                         let mut meta = meta.clone();
                         meta.vehicle_id = server_id;

--- a/kissmp-server/src/lua.rs
+++ b/kissmp-server/src/lua.rs
@@ -47,8 +47,8 @@ impl rlua::UserData for VehicleData {
         methods.add_method("getInGameID", |_, this, _: ()| Ok(this.in_game_id));
         methods.add_method("getID", |_, this, _: ()| Ok(this.server_id));
         methods.add_method("getColor", |_, this, _: ()| Ok(this.color.to_vec()));
-        methods.add_method("getPalete0", |_, this, _: ()| Ok(this.palete_0.to_vec()));
-        methods.add_method("getPalete1", |_, this, _: ()| Ok(this.palete_1.to_vec()));
+        methods.add_method("getPalette0", |_, this, _: ()| Ok(this.palette_0.to_vec()));
+        methods.add_method("getPalette1", |_, this, _: ()| Ok(this.palette_1.to_vec()));
         methods.add_method("getPlate", |_, this, _: ()| Ok(this.plate.clone()));
         methods.add_method("getName", |_, this, _: ()| Ok(this.name.clone()));
         methods.add_method("getOwner", |_, this, _: ()| Ok(this.owner));

--- a/kissmp-server/src/main.rs
+++ b/kissmp-server/src/main.rs
@@ -372,7 +372,7 @@ impl Server {
         connection: quinn::Connection,
         mut client_events_tx: mpsc::Sender<(u32, IncomingEvent)>,
     ) -> anyhow::Result<()> {
-        let mut cmds = streams
+        let mut commands = streams
             .map(|stream| async {
                 let mut stream = stream?;
                 let mut data_type = [0; 1];
@@ -399,7 +399,7 @@ impl Server {
 
         loop {
             let (data_type, data) = select! {
-                data = cmds.try_next() => {
+                data = commands.try_next() => {
                     if let Some(data) = data? {
                         data
                     }

--- a/kissmp-server/src/vehicle/mod.rs
+++ b/kissmp-server/src/vehicle/mod.rs
@@ -15,8 +15,8 @@ pub struct VehicleData {
     pub parts_config: String,
     pub in_game_id: u32,
     pub color: [f32; 4],
-    pub palete_0: [f32; 4],
-    pub palete_1: [f32; 4],
+    pub palette_0: [f32; 4],
+    pub palette_1: [f32; 4],
     pub plate: Option<String>,
     pub name: String,
     #[serde(skip_deserializing)]


### PR DESCRIPTION
Right on the tin. Will most likely interfere with any addons that used the previous `palete` spelling.