### PR TITLE
Development QOL - Project Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+members = [
+    "kissmp-bridge",
+    "kissmp-server",
+    "kissmp-master",
+    "shared"
+]
+default-members = [
+    "kissmp-bridge",
+    "kissmp-server"
+]


### PR DESCRIPTION
Adds a Cargo.toml to the project's root so VSCode and Codium with rust-analyzer can be aware of the other Cargo.toml's and analyze them appropriately without having to open them individually.