### PR TITLE
Master server now accepts "latest" instead of a version

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/kissui.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissui.lua
@@ -1,3 +1,4 @@
+local VERSION = "0.4.1"
 local M = {}
 local http = require("socket.http")
 
@@ -163,7 +164,7 @@ local function refresh_server_list()
   if b and b == "ok" then
     M.bridge_launched = true
   end
-  local b, _, _  = http.request("http://127.0.0.1:3693/"..M.master_addr.."/0.4.1")
+  local b, _, _  = http.request("http://127.0.0.1:3693/"..M.master_addr.."/"..VERSION)
   if b then
     M.server_list = jsonDecode(b) or {}
   end

--- a/kissmp-master/Cargo.toml
+++ b/kissmp-master/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+shared = { path = "../shared" }
 #tide = "0.15.0"
 warp = "0.2"
 serde_json="1.0"

--- a/kissmp-master/src/main.rs
+++ b/kissmp-master/src/main.rs
@@ -7,8 +7,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use warp::Filter;
-
-const VERSION: (u32, u32) = (0, 4);
+use shared::{VERSION_STR, VERSION};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ServerInfo {
@@ -81,7 +80,7 @@ async fn main() {
     let server_list = server_list_r.clone();
     let addresses = addresses_r.clone();
     let ver = warp::path::param().map(move |ver: String| {
-        if ver != String::from("0.4.1") {
+        if ver != VERSION_STR && ver != "latest" {
             return outdated_ver()
         }
         let server_list = server_list.clone();
@@ -121,7 +120,7 @@ fn outdated_ver() -> String {
             description: "You can find updated version of KissMP on a github releases page".to_string(),
             map: "Update to a newer version of KissMP".to_string(),
             port: 0,
-            version: (0, 4),
+            version: VERSION,
             update_time: None
         });
     }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -3,6 +3,7 @@ use vehicle::*;
 use serde::{Serialize, Deserialize};
 
 pub const VERSION: (u32, u32) = (0, 4);
+pub const VERSION_STR: &str = "0.4.1";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ClientInfoPrivate {


### PR DESCRIPTION
Also moves the version constants around so less hunting for them and having them scattered around.

* [ ] Tested

Fixes #58