### PR TITLE
[In Progress] Result Refactor, Remove anyhow dependence, Crate Updates, & Misc Cleanup

### DIFF
--- a/kissmp-server/Cargo.toml
+++ b/kissmp-server/Cargo.toml
@@ -28,5 +28,4 @@ dirs = "3.0"
 igd = { git = "https://github.com/stevefan1999-personal/rust-igd.git", rev = "c2d1f83" }
 ifcfg = "0.1.2"
 async-ctrlc = "1.2"
-ipnetwork = "0.18"
 thiserror = "1.0"

--- a/kissmp-server/Cargo.toml
+++ b/kissmp-server/Cargo.toml
@@ -8,24 +8,24 @@ edition = "2018"
 
 [dependencies]
 shared = { path = "../shared" }
-rand = "0.7.3"
+rand = "0.8"
 serde_json="1.0"
-bincode="1.3.1"
-rmp="0.8.9"
-rmp-serde="0.14.4"
-futures = "0.3.13"
+bincode="1.3"
+rmp="0.8"
+rmp-serde="0.15"
+futures = "0.3"
 quinn = "0.7.1"
-anyhow = "1.0.32"
-rlua = "0.17.0"
-notify = "4.0.15"
-tokio-util = {version = "0.6.5", features = ["codec"]}
+anyhow = "1.0"
+rlua = "0.17"
+notify = "4.0"
+tokio-util = {version = "0.6", features = ["codec"]}
 serde = { version = "1.0", features = ["derive"] }
-reqwest = { version = "0.11.2", default-features = false, features=["rustls-tls"] }
-rcgen = { version = "0.8.2", default-features = false }
+reqwest = { version = "0.11", default-features = false, features=["rustls-tls"] }
+rcgen = { version = "0.8", default-features = false }
 tokio = { version = "1.4", features = ["rt-multi-thread", "time", "macros", "sync", "io-util", "io-std", "fs"] }
-tokio-stream = "0.1.5"
+tokio-stream = "0.1"
 dirs = "3.0"
 igd = { git = "https://github.com/stevefan1999-personal/rust-igd.git", rev = "c2d1f83" }
-ifcfg = "0.1.2"
+ifcfg = "0.1"
 async-ctrlc = "1.2"
 thiserror = "1.0"

--- a/kissmp-server/Cargo.toml
+++ b/kissmp-server/Cargo.toml
@@ -29,3 +29,4 @@ igd = { git = "https://github.com/stevefan1999-personal/rust-igd.git", rev = "c2
 ifcfg = "0.1.2"
 async-ctrlc = "1.2"
 ipnetwork = "0.18"
+thiserror = "1.0"

--- a/kissmp-server/Cargo.toml
+++ b/kissmp-server/Cargo.toml
@@ -15,7 +15,6 @@ rmp="0.8"
 rmp-serde="0.15"
 futures = "0.3"
 quinn = "0.7.1"
-anyhow = "1.0"
 rlua = "0.17"
 notify = "4.0"
 tokio-util = {version = "0.6", features = ["codec"]}

--- a/kissmp-server/src/error.rs
+++ b/kissmp-server/src/error.rs
@@ -1,0 +1,24 @@
+use ifcfg::IfCfgError;
+use igd::{RemovePortError, SearchError};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum UPnPError {
+    #[error("could not get the system's network interfaces: {0}")]
+    // IfCfgError does not impl std::error::Error so have to have a manual From
+    CouldNotGetInterfaces(IfCfgError),
+    #[error("no interfaces had IPv4 or are connected to the public internet")]
+    NoValidInterfaceIPs,
+    #[error("could not find a gateway: {0}")]
+    CouldNotFindGateway(#[from] SearchError),
+    #[error("with all the valid IPs, could not add a port to any of them")]
+    CouldNotAddPort,
+    #[error("a port was already added for KISSMP, but removing it failed: {0}")]
+    FailedToRemovePort(#[from] RemovePortError)
+}
+
+impl From<IfCfgError> for UPnPError {
+    fn from(e: IfCfgError) -> Self {
+        Self::CouldNotGetInterfaces(e)
+    }
+}

--- a/kissmp-server/src/error.rs
+++ b/kissmp-server/src/error.rs
@@ -1,24 +1,124 @@
 use ifcfg::IfCfgError;
 use igd::{RemovePortError, SearchError};
+use quinn::{ConnectionError, ReadExactError, SendDatagramError, WriteError};
 use thiserror::Error;
+use tokio::sync::mpsc::error::SendError as TokioSendError;
+
+use crate::incoming::IncomingEvent;
+
+#[derive(Error, Debug)]
+pub enum SendServerInfoError {
+
+}
+
+#[derive(Error, Debug)]
+pub enum PlayerConnectError {
+    #[error("server full")]
+    ServerFull
+}
+
+#[derive(Error, Debug)]
+pub enum RecievePlayerInfoError {
+    #[error("could not open the connection")]
+    OpenConnection(#[from] ConnectionError),
+    #[error("reading from the connection failed")]
+    ReadConnection(#[from] ReadExactError),
+    #[error("deseralizing information failed")]
+    Deserialize(#[from] Box<bincode::ErrorKind>),
+    #[error("recieved something else: {0:?}")]
+    RecievedSomethingElse(shared::ClientCommand),
+    #[error("no stream given")]
+    NoStream
+}
+
+#[derive(Error, Debug)]
+pub enum DriveSendError {
+    #[error("sending datagram failed")]
+    SendDatagram(#[from] SendDatagramError),
+    #[error("client disconnected")]
+    Disconnected
+}
+
+#[derive(Error, Debug)]
+pub enum DriveRecieveError {
+    #[error("reading from the connection failed")]
+    ReadConnection(#[from] ReadExactError),
+    #[error("client disconnected")]
+    Disconnected,
+    #[error("recieving command failed")]
+    Commands(#[from] CMDRecieveError),
+    #[error("recieving datagram failed")]
+    Datagram(#[from] DatagramRecieveError)
+}
+
+#[derive(Error, Debug)]
+pub enum SendError {
+    #[error("writing to the connections failed")]
+    WriteAll(#[from] WriteError)
+}
+
+#[derive(Error, Debug)]
+pub enum ListModsError {
+    #[error("reading the mod directory failed")]
+    ReadDirectory(std::io::Error),
+    #[error("getting mod file information failed")]
+    Metadata(std::io::Error)
+}
 
 #[derive(Error, Debug)]
 pub enum UPnPError {
-    #[error("could not get the system's network interfaces: {0}")]
+    #[error("could not get the system's network interfaces")]
     // IfCfgError does not impl std::error::Error so have to have a manual From
-    CouldNotGetInterfaces(IfCfgError),
+    GetInterfaces(IfCfgError),
     #[error("no interfaces had IPv4 or are connected to the public internet")]
     NoValidInterfaceIPs,
     #[error("could not find a gateway: {0}")]
-    CouldNotFindGateway(#[from] SearchError),
+    GatewayNotFound(#[from] SearchError),
     #[error("with all the valid IPs, could not add a port to any of them")]
-    CouldNotAddPort,
-    #[error("a port was already added for KISSMP, but removing it failed: {0}")]
-    FailedToRemovePort(#[from] RemovePortError)
+    AddPort,
+    #[error("a port was already added for KISSMP, but removing it failed")]
+    RemovePort(#[from] RemovePortError)
 }
 
 impl From<IfCfgError> for UPnPError {
     fn from(e: IfCfgError) -> Self {
-        Self::CouldNotGetInterfaces(e)
+        Self::GetInterfaces(e)
     }
+}
+
+#[derive(Error, Debug)]
+pub enum TransferFileError {
+    #[error("could not open file")]
+    OpenFile(std::io::Error),
+    #[error("getting file metadata failed")]
+    Metadata(std::io::Error),
+    #[error("connection failed")]
+    Connection(#[from] ConnectionError),
+    #[error("send failed")]
+    Send(#[from] SendError)
+}
+
+#[derive(Error, Debug)]
+pub enum HandleIncomingDataError {
+    #[error("send failed")]
+    Send(#[from] TokioSendError<(u32, IncomingEvent)>),
+    #[error("deseralizing information failed")]
+    Deserialize(#[from] Box<bincode::ErrorKind>)
+}
+
+
+#[derive(Error, Debug)]
+pub enum CMDRecieveError {
+    #[error("could not open the connection")]
+    OpenConnection(#[from] ConnectionError),
+    #[error("reading from the connection failed")]
+    ReadConnection(#[from] ReadExactError),
+}
+
+#[derive(Error, Debug)]
+pub enum DatagramRecieveError {
+    #[error("could not open the connection")]
+    OpenConnection(#[from] ConnectionError),
+    #[error("reading from the connection failed")]
+    ReadConnection(#[from] ReadExactError),
 }

--- a/kissmp-server/src/file_transfer.rs
+++ b/kissmp-server/src/file_transfer.rs
@@ -7,9 +7,9 @@ const CHUNK_SIZE: usize = 65536;
 pub async fn transfer_file(
     connection: quinn::Connection,
     path: &std::path::Path,
-) -> anyhow::Result<()> {
-    let mut file = tokio::fs::File::open(path).await?;
-    let metadata = file.metadata().await?;
+) -> TransferFileResult {
+    let mut file = tokio::fs::File::open(path).await.map_err(TransferFileError::OpenFile)?;
+    let metadata = file.metadata().await.map_err(TransferFileError::Metadata)?;
     let file_length = metadata.len() as u32;
     let file_name = path.file_name().unwrap().to_str().unwrap();
     let mut buf = [0; CHUNK_SIZE];

--- a/kissmp-server/src/incoming.rs
+++ b/kissmp-server/src/incoming.rs
@@ -12,7 +12,7 @@ impl Server {
         id: u32,
         data: Vec<u8>,
         client_events_tx: &mut mpsc::Sender<(u32, IncomingEvent)>,
-    ) -> anyhow::Result<()> {
+    ) -> HandleIncomingDataResult {
         let client_command = bincode::deserialize::<shared::ClientCommand>(&data)?;
         client_events_tx
             .send((id, IncomingEvent::ClientCommand(client_command)))

--- a/kissmp-server/src/lib.rs
+++ b/kissmp-server/src/lib.rs
@@ -22,6 +22,7 @@ use futures::FutureExt;
 use futures::{select, StreamExt, TryStreamExt};
 use quinn::{Certificate, CertificateChain, PrivateKey};
 use std::collections::HashMap;
+use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -600,8 +601,7 @@ pub fn list_mods(
             }
         }
         let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
-        let file = std::fs::File::open(path.clone())?;
-        let metadata = file.metadata()?;
+        let metadata = fs::metadata(path.clone()).map_err(ListModsError::Metadata)?;
         result.push((file_name, metadata.len() as u32));
         raw.push(path);
     }

--- a/kissmp-server/src/lib.rs
+++ b/kissmp-server/src/lib.rs
@@ -1,6 +1,4 @@
-#[recursion_limit = "1024"]
-
-use ipnetwork::Ipv4Network;
+#![recursion_limit = "1024"]
 use shared::vehicle;
 
 pub mod config;
@@ -137,9 +135,8 @@ impl Server {
                     self.upnp_port = Some(port);
                     println!("Fetching public IP address...");
                     let socket = UdpSocket::bind(&addr).unwrap();
-                    socket.connect("kissmp.online:3691");
-                    let mut i = 0;
-                    while i < 5 {
+                    let _ = socket.connect("kissmp.online:3691");
+                    for _ in 0..6 {
                         let _ = socket.send(b"hi");
                         let mut buf = [0; 1024];
                         let r = socket.recv(&mut buf);
@@ -151,7 +148,6 @@ impl Server {
                         } else {
                             println!("Failed to receive public IP, retrying...");
                         }
-                        i += 1;
                     }
                 },
                 Err(e) => {
@@ -200,7 +196,7 @@ impl Server {
         }
         println!("Server is running!");
         if let Some(setup_result) = setup_result {
-            setup_result.send(ServerSetupResult{
+            let _ = setup_result.send(ServerSetupResult{
                 addr: addr.to_string(),
                 port: self.port,
                 is_upnp: self.upnp_port.is_some()
@@ -217,7 +213,7 @@ impl Server {
                 }
                 conn = incoming.select_next_some() => {
                     if let Ok(conn) = conn {
-                        if let Err(e) = self.on_connect(conn, client_events_tx.clone()).await {
+                        if let Err(_) = self.on_connect(conn, client_events_tx.clone()).await {
                             println!("Client has failed to connect to the server");
                         }
                     }
@@ -650,7 +646,7 @@ pub fn upnp_pf(port: u16) -> UPnPResult<u16> {
     for interface in ifs {
         for iface_addr in interface.addresses.iter() {
             match iface_addr.mask {
-                Some(SocketAddr::V4(ipv4_mask)) => {
+                Some(SocketAddr::V4(_ipv4_mask)) => {
                     let ipv4_addr = match iface_addr.address {
                         Some(SocketAddr::V4(ipv4_addr)) => ipv4_addr,
                         _ => continue,

--- a/kissmp-server/src/lib.rs
+++ b/kissmp-server/src/lib.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "1024"]
 use shared::vehicle;
 
 pub mod config;

--- a/kissmp-server/src/result.rs
+++ b/kissmp-server/src/result.rs
@@ -1,3 +1,15 @@
+use shared::ClientInfoPrivate;
+
 use crate::error::*;
 
-pub type UPnPResult<T> = Result<T, UPnPError>;
+pub type SendServerInfoResult = Result<(), SendServerInfoError>;
+pub type PlayerConnectResult = Result<(),PlayerConnectError>;
+pub type RecievePlayerInfoResult = Result<ClientInfoPrivate, RecievePlayerInfoError>;
+pub type DriveSendResult = Result<(), DriveSendError>;
+pub type DriveRecieveResult = Result<(), DriveRecieveError>;
+pub type SendResult = Result<(), SendError>;
+pub type ListModsResult = Result<(Vec<(String, u32)>, Vec<std::path::PathBuf>), ListModsError>;
+type Port = u16;
+pub type UPnPResult = Result<Port, UPnPError>;
+pub type TransferFileResult = Result<(), TransferFileError>;
+pub type HandleIncomingDataResult = Result<(), HandleIncomingDataError>;

--- a/kissmp-server/src/result.rs
+++ b/kissmp-server/src/result.rs
@@ -1,0 +1,3 @@
+use crate::error::*;
+
+pub type UPnPResult<T> = Result<T, UPnPError>;


### PR DESCRIPTION
Instead of a bunch of `match` patterns everywhere, return a `Result` and have errors bubble up to be handled.