### PR TITLE
Added `client:getSteamID` method for the Lua API

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -265,10 +265,16 @@ local function connect(addr, player_name)
   M.connection.server_info = server_info
   M.connection.tickrate = server_info.tickrate
 
+  local steamid64 = ""
+  if Steam and Steam.isWorking then
+    steamid64 = Steam.getAccountIDStr()
+  end
+
   local client_info = {
     ClientInfo = {
       name = player_name,
       secret = generate_secret(server_info.server_identifier),
+      steamid64 = steamid64,
       client_version = {0, 5}
     }
   }

--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -265,9 +265,9 @@ local function connect(addr, player_name)
   M.connection.server_info = server_info
   M.connection.tickrate = server_info.tickrate
 
-  local steamid64 = ""
+  local steamid64 = nil
   if Steam and Steam.isWorking then
-    steamid64 = Steam.getAccountIDStr()
+    steamid64 = Steam.getAccountIDStr() ~= "0" and Steam.getAccountIDStr() or nil
   end
 
   local client_info = {

--- a/kissmp-server/src/lua.rs
+++ b/kissmp-server/src/lua.rs
@@ -160,7 +160,7 @@ struct LuaConnection {
     current_vehicle: Option<u32>,
     ip: String,
     secret: String,
-    steamid64: String
+    steamid64: Option<String>
 }
 
 impl rlua::UserData for LuaConnection {

--- a/kissmp-server/src/lua.rs
+++ b/kissmp-server/src/lua.rs
@@ -155,12 +155,14 @@ struct LuaConnection {
     current_vehicle: u32,
     ip: String,
     secret: String,
+    steamid64: String
 }
 
 impl rlua::UserData for LuaConnection {
     fn add_methods<'lua, M: rlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
         methods.add_method("getIpAddr", |_, this, _: ()| Ok(this.ip.clone()));
         methods.add_method("getSecret", |_, this, _: ()| Ok(this.secret.clone()));
+        methods.add_method("getSteamID", |_, this, _: ()| Ok(this.steamid64.clone()));
         methods.add_method("getID", |_, this, _: ()| Ok(this.id));
         methods.add_method("getCurrentVehicle", |_, this, _: ()| {
             Ok(this.current_vehicle)
@@ -235,6 +237,7 @@ impl Server {
                     name: connection.client_info_public.name.clone(),
                     ip: connection.conn.remote_address().ip().to_string(),
                     secret: connection.client_info_private.secret.clone(),
+                    steamid64: connection.client_info_private.steamid64.clone(),
                 },
             );
         }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -14,6 +14,7 @@ pub const VERSION_STR: &str = "0.5.0";
 pub struct ClientInfoPrivate {
     pub name: String,
     pub secret: String,
+    pub steamid64: String,
     pub client_version: (u32, u32),
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -14,7 +14,7 @@ pub const VERSION_STR: &str = "0.6.0";
 pub struct ClientInfoPrivate {
     pub name: String,
     pub secret: String,
-    pub steamid64: String,
+    pub steamid64: Option<String>,
     pub client_version: (u32, u32),
 }
 


### PR DESCRIPTION
I added this functionality because `secret` isn't persistent so storing users in a DB (On CPR & Verb servers) doesn't work very well.
It's also a good way to identify users.

Usage:
```lua
connections[client_id]:getSteamID()
```