### PR TITLE
Added the ability to enable the debug library in lua

### DIFF
--- a/kissmp-server/src/config.rs
+++ b/kissmp-server/src/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
     pub show_in_server_list: bool,
     pub upnp_enabled: bool,
     pub server_identifier: String,
+    pub unsafe_debug_library: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mods: Option<Vec<String>>,
 }
@@ -30,6 +31,7 @@ impl Default for Config {
             show_in_server_list: false,
             upnp_enabled: false,
             server_identifier: rand_string(),
+            unsafe_debug_library: false,
             mods: None,
         }
     }

--- a/kissmp-server/src/lib.rs
+++ b/kissmp-server/src/lib.rs
@@ -90,7 +90,7 @@ pub struct Server {
 
 impl Server {
     pub fn from_config(config: config::Config) -> Self {
-        let (lua, receiver) = lua::setup_lua();
+        let (lua, receiver) = lua::setup_lua(config.unsafe_debug_library);
         let (watcher_tx, watcher_rx) = std::sync::mpsc::channel();
         let lua_watcher =
             notify::Watcher::new(watcher_tx, std::time::Duration::from_secs(2)).unwrap();

--- a/kissmp-server/src/lua.rs
+++ b/kissmp-server/src/lua.rs
@@ -351,8 +351,14 @@ pub struct MpscChannelSender(mpsc::Sender<LuaCommand>);
 
 impl rlua::UserData for MpscChannelSender {}
 
-pub fn setup_lua() -> (rlua::Lua, mpsc::Receiver<LuaCommand>) {
-    let lua = rlua::Lua::new();
+pub fn setup_lua(debug_lib: bool) -> (rlua::Lua, mpsc::Receiver<LuaCommand>) {
+    let lua;
+    if debug_lib {
+        unsafe { lua = rlua::Lua::unsafe_new_with(rlua::StdLib::all()); };
+    } else {
+        lua = rlua::Lua::new();
+    }
+
     let (tx, rx) = mpsc::channel();
     lua.context(|lua_ctx| {
         let globals = lua_ctx.globals();


### PR DESCRIPTION
This change will allow server owners/developers to enable the debug library via `config.json`.
I'm not sure if others will find a use for it but there's always a chance. It's also nice to have just in case anyone else wants it.