### PR TITLE
Improve connection errors

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -225,6 +225,10 @@ local function connect(addr, player_name)
   M.connection.tcp = socket.tcp()
   M.connection.tcp:settimeout(3.0)
   local connected, err = M.connection.tcp:connect("127.0.0.1", "7894")
+  if not connected then
+    kissui.chat.add_message("Failed to connect to bridge, make sure it's running.", kissui.COLOR_RED)
+    return
+  end
 
   -- Send server address to the bridge
   local addr_lenght = ffi.string(ffi.new("uint32_t[?]", 1, {#addr}), 4)
@@ -238,7 +242,7 @@ local function connect(addr, player_name)
       return
     end
   else
-    kissui.chat.add_message("Failed to confirm connection. Check if bridge is running.", kissui.COLOR_RED)
+    kissui.chat.add_message("Server appears to be offline", kissui.COLOR_RED)
     return
   end
 

--- a/kissmp-bridge/src/main.rs
+++ b/kissmp-bridge/src/main.rs
@@ -10,7 +10,7 @@ use tokio::net::{TcpListener, TcpStream};
 #[macro_use]
 extern crate log;
 
-const SERVER_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const SERVER_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
 const CONNECTED_BYTE: &[u8] = &[1];
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Previously, when the bridge is running but a server isn't if you try to connect to it, the chat will say make sure the bridge is running.

Now it tells you if the issue is the bridge or the server.
Not a significant change but nice to have, up to you if you accept the PR.