### PR TITLE
Use `FS:stat()` to get mod file size

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/kissmods.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmods.lua
@@ -93,14 +93,12 @@ local function update_status(mod)
   if not search_results[1] then
     mod.status = "missing"
   else
-    local file = io.open(search_results[1])
-    local len = file:seek("end")
+    local len = FS:stat(search_results[1]).filesize
     if len ~= mod.size then
       mod.status = "different"
     else
       mod.status = "ok"
     end
-    io.close(file)
   end
 end
 


### PR DESCRIPTION
Fixes #126
The `file:seek("end")` method used in `kissmods.lua` to get file size crashed on Linux. `FS:stat()` works correctly both on Windows and Linux.
Works correctly on top of 0.5.0. Works correctly with current master branch as well.