### PR TITLE
change config to have proper defaults

### DIFF
--- a/kissmp-server/src/config.rs
+++ b/kissmp-server/src/config.rs
@@ -28,7 +28,7 @@ impl Default for Config {
             max_vehicles_per_client: 3,
             port: 3698,
             show_in_server_list: false,
-            upnp_enabled: false,
+            upnp_enabled: true,
             server_identifier: rand_string(),
             mods: None,
         }


### PR DESCRIPTION
having upnp disabled by default wastes users time who dont want to, or are unable to (such as lang barriers) to read the wiki.
it also just makes the server faster for initial setup, which is good :D