### PR TITLE
Deny downloading mods from a public server

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -447,6 +447,12 @@ local function onUpdate(dt)
         end
       end
     elseif string.byte(msg_type) == 0 then -- Binary data
+      if M.is_server_public then
+        kissui.chat.add_message("Connection rejected: Server tried to download a mod.", kissui.COLOR_RED)
+        disconnect()
+        return
+      end
+
       local name_b = M.connection.tcp:receive(4)
       if not name_b then break end
 


### PR DESCRIPTION
So far `is_server_public` was checked when there were missing mods the server announced (via `ServerInfo`.)
However, the server can forcefully send over a `FileChunk` and the client would download it with no checks.
This doesn't resolve the issue (the client shouldn't download mods it doesn't know about), but it does make sure public servers can't exploit it.

I'm not sure if this PR will clash with any other potential changes, possibly if the mod downloading code is fully rewritten, so this might just be a temporary fix.