### PR TITLE
Settings rework, Nametag rework

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/kissconfig.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissconfig.lua
@@ -4,6 +4,7 @@ local queue_settings_save_timer = 0
 local target_config_version = 2
 local defaults = {}
 local config = {}
+local magic_config = {}
 
 local function generate_base_secret()
   math.randomseed(os.time() + os.clock())
@@ -62,7 +63,7 @@ end
 local function set_setting(id, val)
   config[id] = val
   queue_settings_save_timer = 2
-  extensions.hook("onKissMPSettingsChanged", config)
+  extensions.hook("onKissMPSettingsChanged", magic_config)
 end
 
 local function get_setting(id)
@@ -96,7 +97,6 @@ local function load_config()
     config["security.base_secret_v2"] = generate_base_secret()
   end
 
-  local magic_config = {}
   local mt = {
     __index = function(_, key)
       return get_setting(key)

--- a/KISSMultiplayer/lua/ge/extensions/kissconfig.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissconfig.lua
@@ -1,5 +1,9 @@
 local M = {}
-local imgui = ui_imgui
+
+local queue_settings_save_timer = 0
+local target_config_version = 2
+local defaults = {}
+local config = {}
 
 local function generate_base_secret()
   math.randomseed(os.time() + os.clock())
@@ -11,58 +15,96 @@ local function generate_base_secret()
   return result
 end
 
-local function save_config()
-  local secret = network.base_secret or "None"
-  if secret == "None" then
-    secret = generate_base_secret()
+local function update_settings(oldconfig)
+  -- update from original to version 2 (better structure)
+  if not oldconfig.header then
+    local config_data = {}
+    config_data["security.base_secret_v2"] = oldconfig.base_secret_v2
+    config_data["perf.enable_view_distance"] = oldconfig.enable_view_distance
+    config_data["perf.view_distance"] = oldconfig.view_distance
+    config_data["players.show_drivers"] = oldconfig.show_drivers
+    config_data["players.show_nametags"] = oldconfig.show_nametags
+    config_data["ui.addr"] = oldconfig.addr
+    config_data["ui.name"] = oldconfig.name
+    config_data["ui.window_opacity"] = oldconfig.window_opacity
+
+    return config_data
   end
+end
+
+local function save_config()
   local result = {
-    name = ffi.string(kissui.player_name),
-    addr = ffi.string(kissui.addr),
-    show_nametags = kissui.show_nametags[0],
-    show_drivers = kissui.show_drivers[0],
-    window_opacity = kissui.window_opacity[0],
-    enable_view_distance = kissui.enable_view_distance[0],
-    view_distance = kissui.view_distance[0],
-    base_secret_v2 = secret
+    header = {
+      version = 2
+    },
+    data = {}
   }
+  for k,v in pairs(config) do
+    if k == "security.base_secret_v2" or k == "ui.name" or defaults[k] ~= nil then
+      result.data[k] = v
+    else
+      log("W", "kissmp.kissconfig.save_config", "Unknown settings key: "..tostring(k)..". Will be skipped in save.")
+    end
+  end
+
   jsonWriteFile("/settings/kissmp_config.json", result, true)
 end
 
-local function load_config()
-  if not FS:fileExists("/settings/kissmp_config.json") then
-    if Steam and Steam.isWorking and Steam.accountLoggedIn then
-      kissui.player_name = imgui.ArrayChar(32, Steam.playerName)
+local function update(dt_real)
+  if queue_settings_save_timer > 0 then
+    queue_settings_save_timer = queue_settings_save_timer - dt_real
+    if queue_settings_save_timer <= 0 then
+      save_config()
     end
-    return
   end
-  local config = jsonReadFile("/settings/kissmp_config.json")
-  if not config then return end
+end
 
-  if config.name ~= nil then
-    kissui.player_name = imgui.ArrayChar(32, config.name)
+local function set_setting(id, val)
+  config[id] = val
+  queue_settings_save_timer = 2
+  extensions.hook("onKissMPSettingsChanged", config)
+end
+
+local function get_setting(id)
+  return config[id] == nil and defaults[id] or config[id]
+end
+
+local function load_config()
+  local default_config = jsonReadFile("/settings/kissmp_config_default.json")
+  defaults = default_config.data
+
+  local raw_config = jsonReadFile("/settings/kissmp_config.json")
+  if raw_config then
+    if raw_config.header and raw_config.header.version == target_config_version then
+      config = raw_config.data
+    else
+      config = update_settings(raw_config)
+    end
+  else
+    config = deepcopy(defaults)
+    if Steam and Steam.isWorking and Steam.accountLoggedIn then
+      config.name = Steam.playerName
+    else
+      config.name = "Unknown"
+    end
   end
-  if config.addr ~= nil then
-    kissui.addr = imgui.ArrayChar(128, config.addr)
+
+  if config["security.base_secret_v2"] == nil then
+    config["security.base_secret_v2"] = generate_base_secret()
   end
-  if config.show_nametags ~= nil then
-    kissui.show_nametags[0] = config.show_nametags
-  end
-  if config.show_drivers ~= nil then
-    kissui.show_drivers[0] = config.show_drivers
-  end
-  if config.window_opacity ~= nil then
-    kissui.window_opacity[0] = config.window_opacity
-  end
-  if config.view_distance ~= nil then
-    kissui.view_distance[0] = config.view_distance
-  end
-  if config.enable_view_distance ~= nil then
-    kissui.enable_view_distance[0] = config.enable_view_distance
-  end
-  if config.base_secret_v2 ~= nil then
-    network.base_secret = config.base_secret_v2
-  end
+
+  local magic_config = {}
+  local mt = {
+    __index = function(_, key)
+      return get_setting(key)
+    end, -- use get_setting
+    __newindex = function(_, key, val)
+      set_setting(key, val)
+    end, -- use set_setting
+    __metatable = false --hide metatable to prevent any changes to it
+  }
+  setmetatable(magic_config, mt)
+  extensions.hook("onKissMPSettingsChanged", magic_config)
 end
 
 local function init()
@@ -72,8 +114,12 @@ local function init()
   end
 end
 
+M.set_setting = set_setting
+M.get_setting = get_setting
 M.save_config = save_config
 M.load_config = load_config
+
+M.onUpdate = update
 M.onExtensionLoaded = init
 
 return M

--- a/KISSMultiplayer/lua/ge/extensions/kissconfig.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissconfig.lua
@@ -66,7 +66,10 @@ local function set_setting(id, val)
 end
 
 local function get_setting(id)
-  return config[id] == nil and defaults[id] or config[id]
+  if config[id] == nil then
+    return defaults[id]
+  end
+  return config[id]
 end
 
 local function load_config()

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/chat.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/chat.lua
@@ -69,7 +69,7 @@ local function draw()
   end
   window_title = window_title .. "###chat"
 
-  imgui.SetNextWindowBgAlpha(kissui.window_opacity[0])
+  imgui.SetNextWindowBgAlpha(kissui.window_opacity)
   if imgui.Begin(window_title) then
     local content_width = imgui.GetWindowContentRegionWidth()
     imgui.BeginChild1("ChatWindowUpperContent", imgui.ImVec2(0, -30), true)

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/download.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/download.lua
@@ -21,7 +21,7 @@ local function draw(gui)
   if not kissui.show_download then return end
 
   if not kissui.gui.isWindowVisible("Downloads") then return end
-  imgui.SetNextWindowBgAlpha(kissui.window_opacity[0])
+  imgui.SetNextWindowBgAlpha(kissui.window_opacity)
   imgui.PushStyleVar2(imgui.StyleVar_WindowMinSize, imgui.ImVec2(300, 300))
   imgui.SetNextWindowViewport(imgui.GetMainViewport().ID)
   if imgui.Begin("Downloading Required Mods") then

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/main.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/main.lua
@@ -38,7 +38,7 @@ local function draw(dt)
         imgui.EndTabItem()
       end
       if imgui.BeginTabItem("Settings") then
-        kissui.tabs.settings.draw()
+        kissui.tabs.settings.draw(dt)
         imgui.EndTabItem()
       end
       imgui.EndTabBar()

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/main.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/main.lua
@@ -6,7 +6,7 @@ local function draw(dt)
   if kissui.show_download then return end
 
   if not kissui.gui.isWindowVisible("KissMP") then return end
-  imgui.SetNextWindowBgAlpha(kissui.window_opacity[0])
+  imgui.SetNextWindowBgAlpha(kissui.window_opacity)
   imgui.PushStyleVar2(imgui.StyleVar_WindowMinSize, imgui.ImVec2(300, 300))
   imgui.SetNextWindowViewport(imgui.GetMainViewport().ID)
   if imgui.Begin("KissMP "..network.VERSION_STR) then

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/names.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/names.lua
@@ -1,10 +1,17 @@
 local M = {}
 
 local camera_pos = vec3()
-local vehicle_position = vec3()
+local nametag_position = vec3()
+local vehicle_center = vec3()
+local vehicle_offset = vec3()
 
 local text_color = ColorF(1, 1, 1, 1)
 local background_color = ColorI(0, 0, 0, 255)
+
+M.monotone_names = false
+M.fade_names = true
+M.fade_names_start_distance = 100
+M.use_z_names = true
 
 local function draw()
   camera_pos:set(core_camera.getPositionXYZ())
@@ -12,29 +19,51 @@ local function draw()
     if id ~= network.connection.client_id and player.current_vehicle then
       local vehicle_id = vehiclemanager.id_map[player.current_vehicle] or -1
       local vehicle = getObjectByID(vehicle_id)
-      if not vehicle or kisstransform.inactive[vehicle_id] then
-        if kissplayers.players[player.current_vehicle] then
-          vehicle_position:set(kissplayers.players[player.current_vehicle]:getPositionXYZ())
-        elseif kisstransform.raw_transforms[player.current_vehicle] then
-          local position = kisstransform.raw_transforms[player.current_vehicle].position
-          vehicle_position:set(position[1], position[2], position[3])
-        end
-      else
-        vehicle_position:set(vehicle:getPositionXYZ())
+      local distance = 0
+
+      local raw_transform = kisstransform.raw_transforms[player.current_vehicle]
+      if vehicle and vehicle:getActive() then
+        vehicle_center:set(be:getObjectOOBBCenterXYZ(vehicle_id))
+        vehicle_offset:set(be:getObjectOOBBHalfAxisXYZ(vehicle_id, 2))
+
+        nametag_position:setAdd2(vehicle_center, vehicle_offset)
+        distance = vehicle_center:distance(camera_pos)
+      elseif raw_transform then
+        local position = raw_transform.position
+        nametag_position:set(position[1], position[2], position[3])
+
+        distance = nametag_position:distance(camera_pos)
+        nametag_position.z = nametag_position.z + 1.6
       end
 
-      local distance = vehicle_position:distance(camera_pos) or 0
-      vehicle_position.z = vehicle_position.z + 1.6
-      debugDrawer:drawTextAdvanced(
-        vehicle_position,
-        player.name.." ("..tostring(math.floor(distance)).."m)",
-        text_color,
-        true,
-        false,
-        background_color,
-        false,
-        false
-      )
+      if not M.monotone_names then
+        local r,g,b,_ = kissplayers.get_player_color(id)
+        text_color.r = r
+        text_color.g = g
+        text_color.b = b
+      end
+
+      if M.fade_names then
+        local factor = linearScale(distance, M.fade_names_start_distance, M.fade_names_start_distance + 100, 1, 0)
+        text_color.a = factor
+        background_color.a = 255 * factor
+      else
+        text_color.a = 1
+        background_color.a = 255
+      end
+
+      if text_color.a > 0 then
+        debugDrawer:drawTextAdvanced(
+          nametag_position,
+          string.format(" %s (%dm) ", player.name, math.floor(distance)),
+          text_color,
+          true,
+          false,
+          background_color,
+          false,
+          M.use_z_names
+        )
+      end
     end
   end
 end

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/names.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/names.lua
@@ -8,10 +8,10 @@ local vehicle_offset = vec3()
 local text_color = ColorF(1, 1, 1, 1)
 local background_color = ColorI(0, 0, 0, 255)
 
-M.monotone_names = false
-M.fade_names = true
-M.fade_names_start_distance = 100
-M.use_z_names = true
+local colorful_names = false
+local fade_names = true
+local fade_names_start_distance = 100
+local use_z_names = true
 
 local function draw()
   camera_pos:set(core_camera.getPositionXYZ())
@@ -36,20 +36,17 @@ local function draw()
         nametag_position.z = nametag_position.z + 1.6
       end
 
-      if not M.monotone_names then
+      if colorful_names then
         local r,g,b,_ = kissplayers.get_player_color(id)
         text_color.r = r
         text_color.g = g
         text_color.b = b
       end
 
-      if M.fade_names then
-        local factor = linearScale(distance, M.fade_names_start_distance, M.fade_names_start_distance + 100, 1, 0)
+      if fade_names then
+        local factor = linearScale(distance, fade_names_start_distance, fade_names_start_distance + 100, 1, 0)
         text_color.a = factor
         background_color.a = 255 * factor
-      else
-        text_color.a = 1
-        background_color.a = 255
       end
 
       if text_color.a > 0 then
@@ -61,13 +58,32 @@ local function draw()
           false,
           background_color,
           false,
-          M.use_z_names
+          use_z_names
         )
       end
     end
   end
 end
 
+local function onKissMPSettingsChanged(config)
+  fade_names = config["players.nametags.fade"]
+  fade_names_start_distance = config["players.nametags.fade_start_distance"]
+  colorful_names = config["players.nametags.colorful"]
+  use_z_names = config["players.nametags.use_z"]
+
+  if not fade_names then
+    text_color.a = 1
+    background_color.a = 255
+  end
+
+  if not colorful_names then
+    text_color.r = 1
+    text_color.g = 1
+    text_color.b = 1
+  end
+end
+
 M.draw = draw
+M.onKissMPSettingsChanged = onKissMPSettingsChanged
 
 return M

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/direct_connect.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/direct_connect.lua
@@ -8,7 +8,8 @@ local function draw()
   if imgui.Button("Connect") then
     local addr = ffi.string(kissui.addr)
     local player_name = ffi.string(kissui.player_name)
-    kissconfig.save_config()
+    kissconfig.set_setting("ui.name", player_name)
+    kissconfig.set_setting("ui.addr", addr)
     network.connect(addr, player_name, false)
   end
 end

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/favorites.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/favorites.lua
@@ -181,8 +181,8 @@ local function draw()
 
       imgui.PopTextWrapPos()
       if imgui.Button("Connect###connect_button_" .. tostring(favorites_count)) then
-        kissconfig.save_config()
         local player_name = ffi.string(kissui.player_name)
+        kissconfig.set_setting("ui.name", player_name)
         -- if it was added manually (direct IP), trust it (false); otherwise, it's public (true)
         network.connect(addr, player_name, not server.added_manually)
       end

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/favorites.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/favorites.lua
@@ -87,7 +87,7 @@ local function draw_add_favorite_window()
   local display_size = imgui.GetIO().DisplaySize
   imgui.SetNextWindowPos(imgui.ImVec2(display_size.x / 2, display_size.y / 2), imgui.Cond_Always, imgui.ImVec2(0.5, 0.5))
 
-  imgui.SetNextWindowBgAlpha(kissui.window_opacity[0])
+  imgui.SetNextWindowBgAlpha(kissui.window_opacity)
   if imgui.Begin("Add Favorite", kissui.gui.getWindowVisibleBoolPtr("Add Favorite"), bit.bor(imgui.WindowFlags_NoScrollbar ,imgui.WindowFlags_NoResize, imgui.WindowFlags_AlwaysAutoResize)) then
     imgui.Text("Name:")
     imgui.SameLine()

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
@@ -22,6 +22,9 @@ local filtered_servers = {}
 local filtered_favorite_servers = {}
 local next_bridge_status_update = 0
 
+local public_scripting = false
+local public_mods = false
+
 M.server_list = {}
 
 -- Server list update and search
@@ -68,6 +71,16 @@ local function filter_server_list(list, term, filter_notfull, filter_notempty, f
     end
     if filter_online and not discard then
       discard = discard or not server_found_in_list
+    end
+
+    -- scripts/mods are not set by filter settings
+    dump("scripts", server_from_list.require_scripts, public_scripting)
+    dump("mods", server_from_list.require_mods, public_mods)
+    if server_from_list.require_scripts and not public_scripting then
+      discard = true
+    end
+    if server_from_list.require_mods and not public_mods then
+      discard = true
     end
 
     if not discard then
@@ -219,8 +232,16 @@ local function draw(dt)
   end
 end
 
+local function onKissMPSettingsChanged(config)
+  public_scripting = config["security.public_scripting"]
+  public_mods = config["security.public_mods"]
+
+  dump("onKissMPSettingsChanged", "server_list")
+end
+
 M.draw = draw
 M.refresh = refresh_server_list
 M.update_filtered = update_filtered_servers
+M.onKissMPSettingsChanged = onKissMPSettingsChanged
 
 return M

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
@@ -1,7 +1,6 @@
 local M = {}
 local imgui = ui_imgui
 local http = require("socket.http")
-http.TIMEOUT = 0.5
 local version = require("lua/ge/extensions/kissmp/version")
 local VERSION_PRTL = version.VERSION_STR
 
@@ -187,8 +186,8 @@ local function draw(dt)
       draw_server_description(server.description)
       imgui.PopTextWrapPos()
       if imgui.Button("Connect###connect_button_" .. tostring(server_count)) then
-        kissconfig.save_config()
         local player_name = ffi.string(kissui.player_name)
+        kissconfig.set_setting("ui.name", player_name)
         network.connect(addr, player_name, true)
       end
 

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
@@ -236,7 +236,7 @@ local function onKissMPSettingsChanged(config)
   public_scripting = config["security.public_scripting"]
   public_mods = config["security.public_mods"]
 
-  dump("onKissMPSettingsChanged", "server_list")
+  update_filtered_servers()
 end
 
 M.draw = draw

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
@@ -74,8 +74,6 @@ local function filter_server_list(list, term, filter_notfull, filter_notempty, f
     end
 
     -- scripts/mods are not set by filter settings
-    dump("scripts", server_from_list.require_scripts, public_scripting)
-    dump("mods", server_from_list.require_mods, public_mods)
     if server_from_list.require_scripts and not public_scripting then
       discard = true
     end

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/server_list.lua
@@ -1,6 +1,7 @@
 local M = {}
 local imgui = ui_imgui
 local http = require("socket.http")
+http.TIMEOUT = 0.5
 local version = require("lua/ge/extensions/kissmp/version")
 local VERSION_PRTL = version.VERSION_STR
 

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -49,7 +49,20 @@ local function draw(dt)
   im.Text("Player Visbility")
   im.Separator()
   render_checkbox("Show Players In Vehicles", "players.show_drivers")
+  im.NewLine()
   render_checkbox("Show Name Tags", "players.show_nametags")
+  render_checkbox("Use Player Colors in Name Tags", "players.nametags.colorful")
+  render_checkbox(nil, "players.nametags.fade")
+  local slider_active = config_items["players.nametags.fade"][0]
+  if not slider_active then
+    im.BeginDisabled()
+  end
+  im.SameLine()
+  render_sliderI("Fade name tags based on distance", "players.nametags.fade_start_distance", 50, 500)
+  if not slider_active then
+    im.EndDisabled()
+  end
+  render_checkbox("Hide name tags behind objects", "players.nametags.use_z")
 
   im.NewLine()
   im.Text("Performance")
@@ -139,6 +152,11 @@ local function onKissMPSettingsChanged(config)
 
   config_items["players.show_nametags"] = im.BoolPtr(config["players.show_nametags"])
   config_items["players.show_drivers"] = im.BoolPtr(config["players.show_drivers"])
+
+  config_items["players.nametags.fade"] = im.BoolPtr(config["players.nametags.fade"])
+  config_items["players.nametags.fade_start_distance"] = im.IntPtr(config["players.nametags.fade_start_distance"])
+  config_items["players.nametags.colorful"] = im.BoolPtr(config["players.nametags.colorful"])
+  config_items["players.nametags.use_z"] = im.BoolPtr(config["players.nametags.use_z"])
 
   config_items["perf.enable_view_distance"] = im.BoolPtr(config["perf.enable_view_distance"])
   config_items["perf.view_distance"] = im.IntPtr(config["perf.view_distance"])

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -19,10 +19,10 @@ local fade_distances = {
 
 local view_distance_name = ""
 local view_distances = {
-  {"Near", 100},
-  {"Balanced", 200},
-  {"Far", 250},
-  {"Very Far", 400}
+  {"Near", 150},
+  {"Balanced", 300},
+  {"Far", 450},
+  {"Very Far", 600}
 }
 
 local function render_checkbox(ui_name, setting_id)

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -9,6 +9,14 @@ local confirm_popup_active = false
 local confirm_player_name = im.ArrayChar(32, "")
 local confirm_timer = 5
 
+local view_distance_name = ""
+local view_distances = {
+  {"Near", 100},
+  {"Balanced", 200},
+  {"Far", 250},
+  {"Very Far", 400}
+}
+
 local function render_checkbox(ui_name, setting_id)
   local checkbox_name = "###"..setting_id
   if ui_name then
@@ -19,22 +27,22 @@ local function render_checkbox(ui_name, setting_id)
   end
 end
 
-local function render_sliderF(ui_name, setting_id,  min, max)
+local function render_sliderF(ui_name, setting_id,  min, max, format)
   local slider_name = "###"..setting_id
   if ui_name then
     slider_name = ui_name..slider_name
   end
-  if im.SliderFloat(slider_name, config_items[setting_id],  min, max) then
+  if im.SliderFloat(slider_name, config_items[setting_id], min, max, format) then
     kissconfig.set_setting(setting_id, config_items[setting_id][0])
   end
 end
 
-local function render_sliderI(ui_name, setting_id, min, max)
+local function render_sliderI(ui_name, setting_id, min, max, format)
   local slider_name = "###"..setting_id
   if ui_name then
     slider_name = ui_name..slider_name
   end
-  if im.SliderInt(slider_name, config_items[setting_id],  min, max) then
+  if im.SliderInt(slider_name, config_items[setting_id], min, max, format) then
     kissconfig.set_setting(setting_id, config_items[setting_id][0])
   end
 end
@@ -60,7 +68,27 @@ local function draw(dt)
     im.BeginDisabled()
   end
   im.SameLine()
-  render_sliderI("View Distance", "perf.view_distance", 50, 500)
+  local cursorX = im.GetCursorPosX()
+  local distance = config_items["perf.view_distance"][0]
+  im.SetNextItemWidth(im.CalcTextSize(view_distance_name).x+im.GetTextLineHeight()+im.GetStyle().FramePadding.x*4)
+  if im.BeginCombo("Maximum Vehicle View Distance", view_distance_name) then
+    for _, v in ipairs(view_distances) do
+      if im.Selectable1(v[1], view_distance_name == v[1]) then
+        distance = v[2]
+        kissconfig.set_setting("perf.view_distance", distance)
+        view_distance_name = v[1]
+      end
+    end
+    if im.Selectable1("Custom", view_distance_name == "Custom") then
+      view_distance_name = "Custom"
+    end
+    im.EndCombo()
+  end
+  if view_distance_name == "Custom" then
+    im.SetCursorPosX(cursorX)
+    render_sliderI("##perf.view_distance", "perf.view_distance", 50, 500, "%dm")
+  end
+  im.SetCursorPosX(cursorX)
   im.PushTextWrapPos(0)
   im.Text("Warning: This feature is experimental. It can introduce a small, usually unnoticeable lag spike when approaching vehicles. It'll also block the ability to switch to vehicles outside of the view distance.")
   im.PopTextWrapPos()
@@ -142,6 +170,18 @@ local function onKissMPSettingsChanged(config)
 
   config_items["perf.enable_view_distance"] = im.BoolPtr(config["perf.enable_view_distance"])
   config_items["perf.view_distance"] = im.IntPtr(config["perf.view_distance"])
+
+  if view_distance_name ~= "Custom" then
+    local distance = config["perf.view_distance"]
+    for _, v in ipairs(view_distances) do
+      if distance == v[2] then
+        view_distance_name = v[1]
+        goto break_loop
+      end
+    end
+    view_distance_name = "Custom"
+    ::break_loop::
+  end
 
   if not confirm_popup_active then
     config_items["security.public_scripting"] = im.BoolPtr(config["security.public_scripting"])

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -42,6 +42,7 @@ end
 local function draw(dt)
   im.Text("User Interface")
   im.Separator()
+  render_sliderF("Interface Scale", "ui.scale", 0.25, 2)
   render_sliderF("Window Opacity", "ui.window_opacity", 0, 1)
 
   im.NewLine()
@@ -129,6 +130,7 @@ local function draw(dt)
 end
 
 local function onKissMPSettingsChanged(config)
+  config_items["ui.scale"] = im.FloatPtr(config["ui.scale"])
   config_items["ui.window_opacity"] = im.FloatPtr(config["ui.window_opacity"])
 
   config_items["players.show_nametags"] = im.BoolPtr(config["players.show_nametags"])

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -149,7 +149,7 @@ local function draw(dt)
 
   if view_distance_name == "Custom" then
     im.SetCursorPosX(cursorX)
-    render_sliderI("##perf.view_distance", "perf.view_distance", 50, 500, "%dm")
+    render_sliderI("##perf.view_distance", "perf.view_distance", 50, 1000, "%dm")
   end
   im.SetCursorPosX(cursorX)
   im.PushTextWrapPos(0)

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -1,8 +1,13 @@
 local M = {}
 local im = ui_imgui
 
-local red_color = im.ImVec4(1,0.25,0.25,1)
+local red_color = im.ImVec4(0.9, 0, 0, 1)
+local mouse_cursor_pos = im.ImVec2(0, 0)
 local config_items = {}
+
+local confirm_popup_active = false
+local confirm_player_name = im.ArrayChar(32, "")
+local confirm_timer = 5
 
 local function render_checkbox(ui_name, setting_id)
   local checkbox_name = "###"..setting_id
@@ -34,7 +39,7 @@ local function render_sliderI(ui_name, setting_id, min, max)
   end
 end
 
-local function draw()
+local function draw(dt)
   im.Text("User Interface")
   im.Separator()
   render_sliderF("Window Opacity", "ui.window_opacity", 0, 1)
@@ -62,13 +67,65 @@ local function draw()
     im.EndDisabled()
   end
 
+  im.PushStyleColor2(im.Col_Text, red_color)
   im.NewLine()
-  im.TextColored(red_color, "Danger Zone")
+  im.Text("Danger Zone")
   im.Separator()
-  render_checkbox("Allow public servers to run commands", "security.public_scripting")
-  im.PushTextWrapPos(0)
-  im.TextColored(red_color, "Warning: ONLY USE PUBLIC SERVERS YOU TRUST WITH THIS ACTIVE. Arbitrary commands can infect your computer and/or steal data.")
-  im.PopTextWrapPos()
+  if im.Checkbox("Allow public servers to run commands", config_items["security.public_scripting"]) then
+    if config_items["security.public_scripting"][0] then
+      im.OpenPopup1("SecurityConfirmationPopup")
+      mouse_cursor_pos = im.GetMousePos()
+      confirm_popup_active = true
+    end
+  end
+  if im.Checkbox("Allow mods from public servers", config_items["security.public_mods"]) then
+    if config_items["security.public_mods"][0] then
+      im.OpenPopup1("SecurityConfirmationPopup")
+      mouse_cursor_pos = im.GetMousePos()
+      confirm_popup_active = true
+    end
+  end
+  im.PopStyleColor()
+
+  im.SetNextWindowPos(mouse_cursor_pos, im.Cond_Always, im.ImVec2(0, 0))
+  if im.BeginPopup("SecurityConfirmationPopup") then
+    im.Text("Servers can infect your computer.")
+    im.Text("Servers can steal your data.")
+    im.Text("ONLY USE PUBLIC SERVERS YOU TRUST.")
+    im.NewLine()
+
+    if confirm_timer > 0 then
+      confirm_timer = confirm_timer - dt
+    end
+    local cant_use = confirm_timer > 0
+    if cant_use then
+      im.BeginDisabled()
+      im.Text("("..math.ceil(confirm_timer)..") Enter your player name to continue:")
+    else
+      im.Text("Enter your player name to continue:")
+    end
+    if im.InputText("##name", confirm_player_name) then
+      if ffi.string(confirm_player_name) == ffi.string(kissui.player_name) then
+        kissconfig.set_setting("security.public_scripting", config_items["security.public_scripting"][0])
+        kissconfig.set_setting("security.public_mods", config_items["security.public_mods"][0])
+        confirm_player_name = im.ArrayChar(32, "")
+        confirm_timer = 5
+        confirm_popup_active = false
+        im.CloseCurrentPopup()
+      end
+    end
+    if cant_use then
+      im.EndDisabled()
+    end
+
+    im.EndPopup()
+  elseif confirm_popup_active then -- user closed it
+    config_items["security.public_scripting"][0] = kissconfig.get_setting("security.public_scripting")
+    config_items["security.public_mods"][0] = kissconfig.get_setting("security.public_mods")
+    confirm_player_name = im.ArrayChar(32, "")
+    confirm_timer = 5
+    confirm_popup_active = false
+  end
 end
 
 local function onKissMPSettingsChanged(config)
@@ -80,7 +137,10 @@ local function onKissMPSettingsChanged(config)
   config_items["perf.enable_view_distance"] = im.BoolPtr(config["perf.enable_view_distance"])
   config_items["perf.view_distance"] = im.IntPtr(config["perf.view_distance"])
 
-  config_items["security.public_scripting"] = im.BoolPtr(config["security.public_scripting"] or false)
+  if not confirm_popup_active then
+    config_items["security.public_scripting"] = im.BoolPtr(config["security.public_scripting"])
+    config_items["security.public_mods"] = im.BoolPtr(config["security.public_mods"])
+  end
 end
 
 M.draw = draw

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -108,7 +108,7 @@ local function draw(dt)
       if ffi.string(confirm_player_name) == ffi.string(kissui.player_name) then
         kissconfig.set_setting("security.public_scripting", config_items["security.public_scripting"][0])
         kissconfig.set_setting("security.public_mods", config_items["security.public_mods"][0])
-        confirm_player_name = im.ArrayChar(32, "")
+        ffi.copy(confirm_player_name, "")
         confirm_timer = 5
         confirm_popup_active = false
         im.CloseCurrentPopup()
@@ -122,7 +122,7 @@ local function draw(dt)
   elseif confirm_popup_active then -- user closed it
     config_items["security.public_scripting"][0] = kissconfig.get_setting("security.public_scripting")
     config_items["security.public_mods"][0] = kissconfig.get_setting("security.public_mods")
-    confirm_player_name = im.ArrayChar(32, "")
+    ffi.copy(confirm_player_name, "")
     confirm_timer = 5
     confirm_popup_active = false
   end

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -1,31 +1,89 @@
 local M = {}
-local imgui = ui_imgui
+local im = ui_imgui
 
-local function draw()
-  if imgui.Checkbox("Show Name Tags", kissui.show_nametags) then
-    kissconfig.save_config()
+local red_color = im.ImVec4(1,0.25,0.25,1)
+local config_items = {}
+
+local function render_checkbox(ui_name, setting_id)
+  local checkbox_name = "###"..setting_id
+  if ui_name then
+    checkbox_name = ui_name..checkbox_name
   end
-  if imgui.Checkbox("Show Players In Vehicles", kissui.show_drivers) then
-    kissconfig.save_config()
-  end
-  imgui.Text("Window Opacity")
-  imgui.SameLine()
-  if imgui.SliderFloat("###window_opacity", kissui.window_opacity, 0, 1) then
-    kissconfig.save_config()
-  end
-  if imgui.Checkbox("Enable view distance (Experimental)", kissui.enable_view_distance) then
-    kissconfig.save_config()
-  end
-  if kissui.enable_view_distance[0] then
-    if imgui.SliderInt("###view_distance", kissui.view_distance, 50, 1000) then
-      kissconfig.save_config()
-    end
-    imgui.PushTextWrapPos(0)
-    imgui.Text("Warning. This feature is experimental. It can introduce a small, usually unnoticeable lag spike when approaching nearby vehicles. It'll also block the ability to switch to far away vehicles")
-    imgui.PopTextWrapPos()
+  if im.Checkbox(checkbox_name, config_items[setting_id]) then
+    kissconfig.set_setting(setting_id, config_items[setting_id][0])
   end
 end
 
+local function render_sliderF(ui_name, setting_id,  min, max)
+  local slider_name = "###"..setting_id
+  if ui_name then
+    slider_name = ui_name..slider_name
+  end
+  if im.SliderFloat(slider_name, config_items[setting_id],  min, max) then
+    kissconfig.set_setting(setting_id, config_items[setting_id][0])
+  end
+end
+
+local function render_sliderI(ui_name, setting_id, min, max)
+  local slider_name = "###"..setting_id
+  if ui_name then
+    slider_name = ui_name..slider_name
+  end
+  if im.SliderInt(slider_name, config_items[setting_id],  min, max) then
+    kissconfig.set_setting(setting_id, config_items[setting_id][0])
+  end
+end
+
+local function draw()
+  im.Text("User Interface")
+  im.Separator()
+  render_sliderF("Window Opacity", "ui.window_opacity", 0, 1)
+
+  im.NewLine()
+  im.Text("Player Visbility")
+  im.Separator()
+  render_checkbox("Show Players In Vehicles", "players.show_drivers")
+  render_checkbox("Show Name Tags", "players.show_nametags")
+
+  im.NewLine()
+  im.Text("Performance")
+  im.Separator()
+  render_checkbox(nil, "perf.enable_view_distance")
+  local slider_active = config_items["perf.enable_view_distance"][0]
+  if not slider_active then
+    im.BeginDisabled()
+  end
+  im.SameLine()
+  render_sliderI("View Distance", "perf.view_distance", 50, 500)
+  im.PushTextWrapPos(0)
+  im.Text("Warning: This feature is experimental. It can introduce a small, usually unnoticeable lag spike when approaching vehicles. It'll also block the ability to switch to vehicles outside of the view distance.")
+  im.PopTextWrapPos()
+  if not slider_active then
+    im.EndDisabled()
+  end
+
+  im.NewLine()
+  im.TextColored(red_color, "Danger Zone")
+  im.Separator()
+  render_checkbox("Allow public servers to run commands", "security.public_scripting")
+  im.PushTextWrapPos(0)
+  im.TextColored(red_color, "Warning: ONLY USE PUBLIC SERVERS YOU TRUST WITH THIS ACTIVE. Arbitrary commands can infect your computer and/or steal data.")
+  im.PopTextWrapPos()
+end
+
+local function onKissMPSettingsChanged(config)
+  config_items["ui.window_opacity"] = im.IntPtr(config["ui.window_opacity"])
+
+  config_items["players.show_nametags"] = im.BoolPtr(config["players.show_nametags"])
+  config_items["players.show_drivers"] = im.BoolPtr(config["players.show_drivers"])
+
+  config_items["perf.enable_view_distance"] = im.BoolPtr(config["perf.enable_view_distance"])
+  config_items["perf.view_distance"] = im.IntPtr(config["perf.view_distance"])
+
+  config_items["security.public_scripting"] = im.BoolPtr(config["security.public_scripting"] or false)
+end
+
 M.draw = draw
+M.onKissMPSettingsChanged = onKissMPSettingsChanged
 
 return M

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -9,6 +9,14 @@ local confirm_popup_active = false
 local confirm_player_name = im.ArrayChar(32, "")
 local confirm_timer = 5
 
+local fade_distance_name = ""
+local fade_distances = {
+  {"Near", 50},
+  {"Balanced", 100},
+  {"Far", 250},
+  {"Very Far", 400}
+}
+
 local view_distance_name = ""
 local view_distances = {
   {"Near", 100},
@@ -66,7 +74,26 @@ local function draw(dt)
     im.BeginDisabled()
   end
   im.SameLine()
-  render_sliderI("Fade name tags based on distance", "players.nametags.fade_start_distance", 50, 500)
+  local cursorX = im.GetCursorPosX()
+  local distance = config_items["players.nametags.fade"][0]
+  im.SetNextItemWidth(im.CalcTextSize(fade_distance_name).x+im.GetTextLineHeight()+im.GetStyle().FramePadding.x*4)
+  if im.BeginCombo("Fade name tags based on distance", fade_distance_name) then
+    for _, v in ipairs(fade_distances) do
+      if im.Selectable1(v[1], fade_distance_name == v[1]) then
+        distance = v[2]
+        kissconfig.set_setting("players.nametags.fade_start_distance", distance)
+        fade_distance_name = v[1]
+      end
+    end
+    if im.Selectable1("Custom", fade_distance_name == "Custom") then
+      fade_distance_name = "Custom"
+    end
+    im.EndCombo()
+  end
+  if fade_distance_name == "Custom" then
+    im.SetCursorPosX(cursorX)
+    render_sliderI("##players.nametags.fade_start_distance", "players.nametags.fade_start_distance", 25, 500, "%dm")
+  end
   if not slider_active then
     im.EndDisabled()
   end
@@ -183,6 +210,21 @@ local function onKissMPSettingsChanged(config)
 
   config_items["players.nametags.fade"] = im.BoolPtr(config["players.nametags.fade"])
   config_items["players.nametags.fade_start_distance"] = im.IntPtr(config["players.nametags.fade_start_distance"])
+
+  -- this will stop the entire widget changing away from custom whenever a distance matches a preset
+  -- but ONLY between game sessions, restarting the game will make it use an actual preset if applicable
+  if fade_distance_name ~= "Custom" then
+    local distance = config["players.nametags.fade_start_distance"]
+    for _, v in ipairs(fade_distances) do
+      if distance == v[2] then
+        fade_distance_name = v[1]
+        goto break_loop
+      end
+    end
+    fade_distance_name = "Custom"
+    ::break_loop::
+  end
+
   config_items["players.nametags.colorful"] = im.BoolPtr(config["players.nametags.colorful"])
   config_items["players.nametags.use_z"] = im.BoolPtr(config["players.nametags.use_z"])
 

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -129,7 +129,7 @@ local function draw(dt)
 end
 
 local function onKissMPSettingsChanged(config)
-  config_items["ui.window_opacity"] = im.IntPtr(config["ui.window_opacity"])
+  config_items["ui.window_opacity"] = im.FloatPtr(config["ui.window_opacity"])
 
   config_items["players.show_nametags"] = im.BoolPtr(config["players.show_nametags"])
   config_items["players.show_drivers"] = im.BoolPtr(config["players.show_drivers"])

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -36,6 +36,7 @@ local function render_checkbox(ui_name, setting_id)
 end
 
 local function render_sliderF(ui_name, setting_id,  min, max, format)
+  format = format or "%.1f"
   local slider_name = "###"..setting_id
   if ui_name then
     slider_name = ui_name..slider_name
@@ -55,11 +56,21 @@ local function render_sliderI(ui_name, setting_id, min, max, format)
   end
 end
 
+local function help_marker(text, desc)
+  im.TextDisabled(text)
+  if im.IsItemHovered(im.HoveredFlags_AllowWhenDisabled) and im.BeginTooltip() then
+    im.PushTextWrapPos(im.GetFontSize() * 35.0);
+    im.TextUnformatted(desc);
+    im.PopTextWrapPos();
+    im.EndTooltip();
+  end
+end
+
 local function draw(dt)
   im.Text("User Interface")
   im.Separator()
-  render_sliderF("Interface Scale", "ui.scale", 0.25, 2)
-  render_sliderF("Window Opacity", "ui.window_opacity", 0, 1)
+  render_sliderF("Interface Scale", "ui.scale", 0.9, 2)
+  render_sliderF("Window Opacity", "ui.window_opacity", 0.3, 1)
 
   im.NewLine()
   im.Text("Player Visbility")
@@ -77,9 +88,9 @@ local function draw(dt)
   local cursorX = im.GetCursorPosX()
   local distance = config_items["players.nametags.fade"][0]
   im.SetNextItemWidth(im.CalcTextSize(fade_distance_name).x+im.GetTextLineHeight()+im.GetStyle().FramePadding.x*4)
-  if im.BeginCombo("Fade name tags based on distance", fade_distance_name) then
+  if im.BeginCombo("Fade Name Tags Based on Distance", fade_distance_name) then
     for _, v in ipairs(fade_distances) do
-      if im.Selectable1(v[1], fade_distance_name == v[1]) then
+      if im.Selectable1(string.format("%s (%dm)", v[1], v[2]), fade_distance_name == v[1]) then
         distance = v[2]
         kissconfig.set_setting("players.nametags.fade_start_distance", distance)
         fade_distance_name = v[1]
@@ -97,7 +108,7 @@ local function draw(dt)
   if not slider_active then
     im.EndDisabled()
   end
-  render_checkbox("Hide name tags behind objects", "players.nametags.use_z")
+  render_checkbox("Hide Name Tags Behind Objects", "players.nametags.use_z")
 
   im.NewLine()
   im.Text("Performance")
@@ -111,9 +122,9 @@ local function draw(dt)
   local cursorX = im.GetCursorPosX()
   local distance = config_items["perf.view_distance"][0]
   im.SetNextItemWidth(im.CalcTextSize(view_distance_name).x+im.GetTextLineHeight()+im.GetStyle().FramePadding.x*4)
-  if im.BeginCombo("Maximum Vehicle View Distance", view_distance_name) then
+  if im.BeginCombo("Limit Vehicle View Distance", view_distance_name) then
     for _, v in ipairs(view_distances) do
-      if im.Selectable1(v[1], view_distance_name == v[1]) then
+      if im.Selectable1(string.format("%s (%dm)", v[1], v[2]), view_distance_name == v[1]) then
         distance = v[2]
         kissconfig.set_setting("perf.view_distance", distance)
         view_distance_name = v[1]
@@ -124,13 +135,24 @@ local function draw(dt)
     end
     im.EndCombo()
   end
+  im.SameLine()
+
+  if not slider_active then
+    im.EndDisabled()
+  end
+  help_marker("(Experimental [?])", [[This feature is experimental.
+  It can introduce a small, usually unnoticeable lag spike when approaching vehicles.
+  It will also block the ability to switch to vehicles outside of the view distance.]])
+  if not slider_active then
+    im.BeginDisabled()
+  end
+
   if view_distance_name == "Custom" then
     im.SetCursorPosX(cursorX)
     render_sliderI("##perf.view_distance", "perf.view_distance", 50, 500, "%dm")
   end
   im.SetCursorPosX(cursorX)
   im.PushTextWrapPos(0)
-  im.Text("Warning: This feature is experimental. It can introduce a small, usually unnoticeable lag spike when approaching vehicles. It'll also block the ability to switch to vehicles outside of the view distance.")
   im.PopTextWrapPos()
   if not slider_active then
     im.EndDisabled()
@@ -140,7 +162,7 @@ local function draw(dt)
   im.NewLine()
   im.Text("Danger Zone")
   im.Separator()
-  if im.Checkbox("Allow public servers to run commands", config_items["security.public_scripting"]) then
+  if im.Checkbox("Allow Public Servers to Run Commands", config_items["security.public_scripting"]) then
     if config_items["security.public_scripting"][0] then
       im.OpenPopup1("SecurityConfirmationPopup")
       mouse_cursor_pos = im.GetMousePos()
@@ -149,7 +171,7 @@ local function draw(dt)
       kissconfig.set_setting("security.public_scripting", false)
     end
   end
-  if im.Checkbox("Allow mods from public servers", config_items["security.public_mods"]) then
+  if im.Checkbox("Allow Public Servers to Install Mods", config_items["security.public_mods"]) then
     if config_items["security.public_mods"][0] then
       im.OpenPopup1("SecurityConfirmationPopup")
       mouse_cursor_pos = im.GetMousePos()

--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/tabs/settings.lua
@@ -77,6 +77,8 @@ local function draw(dt)
       im.OpenPopup1("SecurityConfirmationPopup")
       mouse_cursor_pos = im.GetMousePos()
       confirm_popup_active = true
+    else
+      kissconfig.set_setting("security.public_scripting", false)
     end
   end
   if im.Checkbox("Allow mods from public servers", config_items["security.public_mods"]) then
@@ -84,6 +86,8 @@ local function draw(dt)
       im.OpenPopup1("SecurityConfirmationPopup")
       mouse_cursor_pos = im.GetMousePos()
       confirm_popup_active = true
+    else
+      kissconfig.set_setting("security.public_mods", false)
     end
   end
   im.PopStyleColor()

--- a/KISSMultiplayer/lua/ge/extensions/kissplayers.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissplayers.lua
@@ -1,4 +1,7 @@
 local M = {}
+
+local show_drivers = false
+
 M.lerp_factor = 5
 M.players = {}
 M.players_in_cars = {}
@@ -157,7 +160,7 @@ local function update_player_head(dt, player_id, vehicle)
     driver_cam_pos:set(vehicle:getNodeAbsPositionXYZ(cam_node))
     local r = transform.rotation
 
-    local hide = not kissui.show_drivers[0] or kisstransform.inactive[veh_id]
+    local hide = not show_drivers or kisstransform.inactive[veh_id]
     hide = hide or vehicle == getPlayerVehicle(0) and camera_pos:squaredDistance(driver_cam_pos) < distance_threshold
     if not hide and not M.players_in_cars[player_id] then
       spawn_player_head(player_id, veh_id)
@@ -196,10 +199,15 @@ local function update_players(_, dt_sim)
   end
 end
 
+local function onKissMPSettingsChanged(config)
+  show_drivers = config["players.show_drivers"]
+end
+
 M.spawn_player = spawn_player
 M.delete_player_head = delete_player_head
 
 M.get_player_color = get_player_color
 M.onUpdate = update_players
+M.onKissMPSettingsChanged = onKissMPSettingsChanged
 
 return M

--- a/KISSMultiplayer/lua/ge/extensions/kisstransform.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kisstransform.lua
@@ -2,6 +2,8 @@ local M = {}
 
 local string_buffer = require("string.buffer")
 
+local view_distance = nil
+
 M.raw_transforms = {}
 M.received_transforms = {}
 M.local_transforms = {}
@@ -28,7 +30,6 @@ local function update(dt)
   -- Don't apply velocity while paused. If we do, velocity gets stored up and released when the game resumes.
   local apply_velocity = not bullettime.getPause()
   camera_pos:set(core_camera.getPositionXYZ())
-  local view_distance = kissui.enable_view_distance[0] and kissui.view_distance[0] * kissui.view_distance[0] or nil
   for id, transform in pairs(M.received_transforms) do
     --apply_transform(dt, id, transform, apply_velocity)
     local vehicle = getObjectByID(id)
@@ -75,8 +76,13 @@ local function push_transform(id, t)
   M.local_transforms[id] = string_buffer.decode(t)
 end
 
+local function onKissMPSettingsChanged(config)
+  view_distance = config["perf.enable_view_distance"] and config["perf.view_distance"] * config["perf.view_distance"] or nil
+end
+
 M.update_vehicle_transform = update_vehicle_transform
 M.push_transform = push_transform
 M.onUpdate = update
+M.onKissMPSettingsChanged = onKissMPSettingsChanged
 
 return M

--- a/KISSMultiplayer/lua/ge/extensions/kissui.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissui.lua
@@ -15,7 +15,7 @@ M.tabs = {
 
 M.dependencies = {"ui_imgui"}
 
-M.master_addr = "http://kissmp.thehellbox.ru:3692/"
+M.master_addr = "http://kissmp.online:3692/"
 M.bridge_launched = false
 
 M.show_download = false
@@ -32,15 +32,12 @@ M.gui = {setupEditorGuiTheme = nop}
 local imgui = ui_imgui
 
 local ui_showing = false
+local names_visible = false
 
 -- TODO: Move all this somewhere else. Some of settings aren't even related to UI
 M.addr = imgui.ArrayChar(128)
 M.player_name = imgui.ArrayChar(32, "Unknown")
-M.show_nametags = imgui.BoolPtr(true)
-M.show_drivers = imgui.BoolPtr(true)
-M.window_opacity = imgui.FloatPtr(0.8)
-M.enable_view_distance = imgui.BoolPtr(true)
-M.view_distance = imgui.IntPtr(300)
+M.window_opacity = 0.8
 
 local function show_ui()
   M.gui.showWindow("KissMP")
@@ -91,14 +88,30 @@ local function onUpdate(dt)
   main_window.draw(dt)
   M.chat.draw()
   M.download_window.draw()
+
   if M.incorrect_install then
-     draw_incorrect_install()
+    draw_incorrect_install()
   end
-  if (not M.force_disable_nametags) and M.show_nametags[0] then
+
+  if not M.force_disable_nametags and names_visible then
     names.draw()
   end
 end
 
+local function onKissMPSettingsChanged(config)
+  M.addr = imgui.ArrayChar(32, config["ui.addr"])
+  M.player_name = imgui.ArrayChar(32, config["ui.name"])
+  M.window_opacity = config["ui.window_opacity"]
+  names_visible = config["players.show_nametags"]
+
+  for _, v in pairs(M.tabs) do
+    if v.onKissMPSettingsChanged then
+      v.onKissMPSettingsChanged(config)
+    end
+  end
+end
+
+M.onKissMPSettingsChanged = onKissMPSettingsChanged
 M.onExtensionLoaded = open_ui
 M.onUpdate = onUpdate
 

--- a/KISSMultiplayer/lua/ge/extensions/kissui.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissui.lua
@@ -15,7 +15,7 @@ M.tabs = {
 
 M.dependencies = {"ui_imgui"}
 
-M.master_addr = "http://kissmp.online:3692/"
+M.master_addr = "http://kissmp.thehellbox.ru:3692/"
 M.bridge_launched = false
 
 M.show_download = false

--- a/KISSMultiplayer/lua/ge/extensions/kissui.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissui.lua
@@ -124,6 +124,7 @@ local function onKissMPSettingsChanged(config)
       v.onKissMPSettingsChanged(config)
     end
   end
+  names.onKissMPSettingsChanged(config)
 end
 
 M.onKissMPSettingsChanged = onKissMPSettingsChanged

--- a/KISSMultiplayer/lua/ge/extensions/kissui.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissui.lua
@@ -99,8 +99,8 @@ local function onUpdate(dt)
 end
 
 local function onKissMPSettingsChanged(config)
-  M.addr = imgui.ArrayChar(32, config["ui.addr"])
-  M.player_name = imgui.ArrayChar(32, config["ui.name"])
+  ffi.copy(M.addr, config["ui.addr"] or "")
+  ffi.copy(M.player_name, config["ui.name"] or "")
   M.window_opacity = config["ui.window_opacity"]
   names_visible = config["players.show_nametags"]
 

--- a/KISSMultiplayer/lua/ge/extensions/kissui.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissui.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local imgui_utils = require("ui/imguiUtils")
-
 local main_window = require("kissmp.ui.main")
 M.chat = require("kissmp.ui.chat")
 M.download_window = require("kissmp.ui.download")
@@ -83,13 +81,19 @@ local function draw_incorrect_install()
   imgui.End()
 end
 
+local function change_scale(new_uiscale)
+  imgui.uiscale[0] = new_uiscale
+  local io = imgui.GetIO(io)
+  imgui.ImGuiIO_FontGlobalScale(io, imgui.uiscale[0])
+end
+
 local function onUpdate(dt)
   if getMissionFilename() ~= '' and not vehiclemanager.is_network_session then
     return
   end
 
-  local prev_ui_Scale = imgui.uiscale[0]
-  imgui_utils.changeUIScale(uiscale)
+  local prev_ui_scale = imgui.uiscale[0]
+  change_scale(uiscale)
   imgui.PushFont3("segoeui_regular") -- update font size
 
   main_window.draw(dt)
@@ -104,7 +108,7 @@ local function onUpdate(dt)
     names.draw()
   end
 
-  imgui_utils.changeUIScale(prev_ui_Scale)
+  change_scale(prev_ui_scale)
   imgui.PopFont() -- reset font size
 end
 
@@ -112,7 +116,7 @@ local function onKissMPSettingsChanged(config)
   ffi.copy(M.addr, config["ui.addr"] or "")
   ffi.copy(M.player_name, config["ui.name"] or "")
   M.window_opacity = config["ui.window_opacity"]
-  uiscale = config["ui.scale"]
+  uiscale = config["ui.scale"] * imgui.GetWindowDpiScale()
   names_visible = config["players.show_nametags"]
 
   for _, v in pairs(M.tabs) do

--- a/KISSMultiplayer/lua/ge/extensions/kissui.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissui.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local imgui_utils = require("ui/imguiUtils")
+
 local main_window = require("kissmp.ui.main")
 M.chat = require("kissmp.ui.chat")
 M.download_window = require("kissmp.ui.download")
@@ -33,8 +35,8 @@ local imgui = ui_imgui
 
 local ui_showing = false
 local names_visible = false
+local uiscale = 1
 
--- TODO: Move all this somewhere else. Some of settings aren't even related to UI
 M.addr = imgui.ArrayChar(128)
 M.player_name = imgui.ArrayChar(32, "Unknown")
 M.window_opacity = 0.8
@@ -85,6 +87,11 @@ local function onUpdate(dt)
   if getMissionFilename() ~= '' and not vehiclemanager.is_network_session then
     return
   end
+
+  local prev_ui_Scale = imgui.uiscale[0]
+  imgui_utils.changeUIScale(uiscale)
+  imgui.PushFont3("segoeui_regular") -- update font size
+
   main_window.draw(dt)
   M.chat.draw()
   M.download_window.draw()
@@ -96,12 +103,16 @@ local function onUpdate(dt)
   if not M.force_disable_nametags and names_visible then
     names.draw()
   end
+
+  imgui_utils.changeUIScale(prev_ui_Scale)
+  imgui.PopFont() -- reset font size
 end
 
 local function onKissMPSettingsChanged(config)
   ffi.copy(M.addr, config["ui.addr"] or "")
   ffi.copy(M.player_name, config["ui.name"] or "")
   M.window_opacity = config["ui.window_opacity"]
+  uiscale = config["ui.scale"]
   names_visible = config["players.show_nametags"]
 
   for _, v in pairs(M.tabs) do

--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -17,6 +17,9 @@ local socket = require("socket")
 local messagepack = require("lua/common/libs/Lua-MessagePack/MessagePack")
 local ping_send_time = 0
 
+local public_scripting = false
+local public_mods = false
+
 M.players = {}
 M.socket = socket
 M.base_secret = "None"
@@ -139,7 +142,7 @@ local function check_lua(l)
 end
 
 local function handle_lua(data)
-  if M.is_server_public then
+  if M.is_server_public and not public_scripting then
     log("W", "kissmp.network.handle_lua", "Blocked arbitrary GE Lua command from public server.")
     return
   end
@@ -150,7 +153,7 @@ local function handle_lua(data)
 end
 
 local function handle_vehicle_lua(data)
-  if M.is_server_public then
+  if M.is_server_public and not public_scripting then
     log("W", "kissmp.network.handle_vehicle_lua", "Blocked arbitrary vehicle Lua command from public server.")
     return
   end
@@ -281,6 +284,8 @@ end
 
 local function connect(addr, player_name, is_public)
   M.is_server_public = is_public or false
+  public_scripting = kissconfig.get_setting("security.public_scripting")
+  public_mods = kissconfig.get_setting("security.public_mods")
 
   if M.connection.connected then
     disconnect()
@@ -380,7 +385,7 @@ local function connect(addr, player_name, is_public)
   end
   if #missing_mods > 0 then
     -- Do not allow public servers to force mod downloads
-    if M.is_server_public then
+    if M.is_server_public and not public_mods then
       kissui.chat.add_message("Connection rejected: Missing mods.", kissui.COLOR_RED)
       disconnect()
       return

--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -471,7 +471,7 @@ local function onUpdate(dt)
       end
 
     elseif string.byte(msg_type) == 0 then -- Binary data
-      if M.is_server_public then
+      if M.is_server_public and not public_mods then
         kissui.chat.add_message("Connection rejected: Server tried to download a mod.", kissui.COLOR_RED)
         disconnect()
         return

--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -329,7 +329,15 @@ local function connect(addr, player_name, is_public)
   local server_info = jsonDecode(received).ServerInfo
   if not server_info then
     log("E", "kissmp.network.connect", "Failed to fetch server info. Aborting.")
+    disconnect()
     return
+  else
+    if (server_info.require_scripts and not public_scripting) or (server_info.require_mods and not public_mods) then
+      kissui.chat.add_message("Connection rejected: Missing permissions.", kissui.COLOR_RED)
+      log("E", "kissmp.network.connect", "Missing permissions. Server requirements do not match game settings.")
+      disconnect()
+      return
+    end
   end
   log("I", "kissmp.network.connect", "Server name: "..server_info.name)
   log("I", "kissmp.network.connect", "Player count: "..server_info.player_count)

--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -568,6 +568,10 @@ local function onUpdate(dt)
   end
 end
 
+local function onKissMPSettingsChanged(config)
+  M.base_secret = config["security.base_secret_v2"]
+end
+
 local function get_client_id()
   return M.connection.client_id
 end
@@ -579,5 +583,6 @@ M.cancel_download = cancel_download
 M.send_data = send_data
 M.onUpdate = onUpdate
 M.onExtensionLoaded = onExtensionLoaded
+M.onKissMPSettingsChanged = onKissMPSettingsChanged
 
 return M

--- a/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
+++ b/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
@@ -184,6 +184,7 @@ end
 
 local camera_pos = vec3()
 local transform_pos = vec3()
+local view_distance = nil
 
 local function spawn_vehicle(data)
   local model_info = core_vehicles.getModel(data.name)
@@ -193,7 +194,6 @@ local function spawn_vehicle(data)
   end
 
   local away = true
-  local view_distance = kissui.enable_view_distance[0] and kissui.view_distance[0] * kissui.view_distance[0] or nil
   if view_distance then
     if kisstransform.raw_transforms[data.server_id] then
       local position = kisstransform.raw_transforms[data.server_id].position
@@ -300,7 +300,6 @@ local function onUpdate(dt)
     end
   end
   if not (M.loading_map or M.delay_spawns) then
-    local view_distance = kissui.enable_view_distance[0] and kissui.view_distance[0] * kissui.view_distance[0] or nil
     local to_remove = {}
     for k, vehicle in pairs(M.vehicle_buffer) do
       local t = kisstransform.raw_transforms[k]
@@ -630,7 +629,12 @@ local function onMissionLoaded(mission)
   first_vehicle = true
 end
 
+local function onKissMPSettingsChanged(config)
+  view_distance = config["perf.enable_view_distance"] and config["perf.view_distance"] * config["perf.view_distance"] or nil
+end
+
 M.onUpdate = onUpdate
+M.onKissMPSettingsChanged = onKissMPSettingsChanged
 M.get_current_time = get_current_time
 M.update_vehicle = update_vehicle
 M.send_vehicle_config = send_vehicle_config

--- a/KISSMultiplayer/settings/kissmp_config_default.json
+++ b/KISSMultiplayer/settings/kissmp_config_default.json
@@ -7,6 +7,8 @@
     "perf.view_distance": 200,
     "players.show_drivers": true,
     "players.show_nametags": true,
+    "security.public_mods": false,
+    "security.public_scripting": false,
     "ui.addr": "",
     "ui.window_opacity": 0.80000001192093
   }

--- a/KISSMultiplayer/settings/kissmp_config_default.json
+++ b/KISSMultiplayer/settings/kissmp_config_default.json
@@ -4,17 +4,17 @@
   },
   "data": {
     "perf.enable_view_distance": false,
-    "perf.view_distance": 200,
-    "players.nametags.fade": true,
+    "perf.view_distance": 300,
+    "players.nametags.fade": false,
     "players.nametags.fade_start_distance": 100,
     "players.nametags.colorful": true,
-    "players.nametags.use_z": true,
+    "players.nametags.use_z": false,
     "players.show_drivers": true,
     "players.show_nametags": true,
     "security.public_mods": false,
     "security.public_scripting": false,
     "ui.addr": "",
     "ui.scale": 1,
-    "ui.window_opacity": 0.80000001192093
+    "ui.window_opacity": 0.8
   }
 }

--- a/KISSMultiplayer/settings/kissmp_config_default.json
+++ b/KISSMultiplayer/settings/kissmp_config_default.json
@@ -1,0 +1,13 @@
+{
+  "header": {
+    "version": 2
+  },
+  "data": {
+    "perf.enable_view_distance": false,
+    "perf.view_distance": 200,
+    "players.show_drivers": true,
+    "players.show_nametags": true,
+    "ui.addr": "",
+    "ui.window_opacity": 0.80000001192093
+  }
+}

--- a/KISSMultiplayer/settings/kissmp_config_default.json
+++ b/KISSMultiplayer/settings/kissmp_config_default.json
@@ -10,6 +10,7 @@
     "security.public_mods": false,
     "security.public_scripting": false,
     "ui.addr": "",
+    "ui.scale": 1,
     "ui.window_opacity": 0.80000001192093
   }
 }

--- a/KISSMultiplayer/settings/kissmp_config_default.json
+++ b/KISSMultiplayer/settings/kissmp_config_default.json
@@ -5,6 +5,10 @@
   "data": {
     "perf.enable_view_distance": false,
     "perf.view_distance": 200,
+    "players.nametags.fade": true,
+    "players.nametags.fade_start_distance": 100,
+    "players.nametags.colorful": true,
+    "players.nametags.use_z": true,
     "players.show_drivers": true,
     "players.show_nametags": true,
     "security.public_mods": false,

--- a/kissmp-master/src/main.rs
+++ b/kissmp-master/src/main.rs
@@ -14,7 +14,9 @@ pub struct ServerInfo {
     map: String,
     port: u16,
     version: (u32, u32),
+    #[serde(default)]
     require_scripts: bool,
+    #[serde(default)]
     require_mods: bool,
     #[serde(skip)]
     update_time: Option<std::time::Instant>,

--- a/kissmp-master/src/main.rs
+++ b/kissmp-master/src/main.rs
@@ -14,6 +14,8 @@ pub struct ServerInfo {
     map: String,
     port: u16,
     version: (u32, u32),
+    require_scripts: bool,
+    require_mods: bool,
     #[serde(skip)]
     update_time: Option<std::time::Instant>,
 }
@@ -139,7 +141,9 @@ fn outdated_ver() -> String {
             map: "Update to a newer version of KissMP".to_string(),
             port: 0,
             version: VERSION,
-            update_time: None
+            update_time: None,
+            require_scripts: false,
+            require_mods: false,
         });
     }
     serde_json::to_string(&server_list).unwrap()

--- a/kissmp-server/src/config.rs
+++ b/kissmp-server/src/config.rs
@@ -16,7 +16,6 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mods: Option<Vec<String>>,
     pub require_scripts: bool,
-    pub require_mods: bool,
 }
 
 impl Default for Config {
@@ -34,7 +33,6 @@ impl Default for Config {
             server_identifier: rand_string(),
             mods: None,
             require_scripts: false,
-            require_mods: false,
         }
     }
 }

--- a/kissmp-server/src/config.rs
+++ b/kissmp-server/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub server_identifier: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mods: Option<Vec<String>>,
+    pub require_scripts: bool,
+    pub require_mods: bool,
 }
 
 impl Default for Config {
@@ -31,6 +33,8 @@ impl Default for Config {
             upnp_enabled: false,
             server_identifier: rand_string(),
             mods: None,
+            require_scripts: false,
+            require_mods: false,
         }
     }
 }

--- a/kissmp-server/src/lib.rs
+++ b/kissmp-server/src/lib.rs
@@ -120,10 +120,12 @@ impl Server {
             server_identifier: config.server_identifier,
             upnp_enabled: config.upnp_enabled,
             public_address: None,
-            mods: config.mods,
+            mods: config.mods.clone(),
             tick: 0,
             require_scripts: config.require_scripts,
-            require_mods: config.require_mods,
+            require_mods: crate::list_mods(config.mods)
+                .map(|(m, _)| !m.is_empty())
+                .unwrap_or(false),
         }
     }
     pub async fn run(

--- a/kissmp-server/src/lib.rs
+++ b/kissmp-server/src/lib.rs
@@ -88,6 +88,8 @@ pub struct Server {
     public_address: Option<String>,
     mods: Option<Vec<String>>,
     tick: u64,
+    require_scripts: bool,
+    require_mods: bool,
 }
 
 impl Server {
@@ -120,6 +122,8 @@ impl Server {
             public_address: None,
             mods: config.mods,
             tick: 0,
+            require_scripts: config.require_scripts,
+            require_mods: config.require_mods,
         }
     }
     pub async fn run(
@@ -266,7 +270,9 @@ impl Server {
             "description": self.description.clone(),
             "map": self.map.clone(),
             "port": self.port,
-            "version": shared::VERSION
+            "version": shared::VERSION,
+            "require_scripts": self.require_scripts,
+            "require_mods": self.require_mods,
         })
         .to_string();
 
@@ -422,6 +428,8 @@ impl Server {
                 max_vehicles_per_client: self.max_vehicles_per_client,
                 mods: list_mods(self.mods.clone()).unwrap().0,
                 server_identifier: self.server_identifier.clone(),
+                require_scripts: self.require_scripts,
+                require_mods: self.require_mods,
             }))
             .unwrap();
         // Sender

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -52,6 +52,8 @@ pub struct ServerInfo {
     pub max_vehicles_per_client: u8,
     pub mods: Vec<(String, u32)>,
     pub server_identifier: String,
+    pub require_scripts: bool,
+    pub require_mods: bool
 }
 
 impl ClientInfoPublic {


### PR DESCRIPTION
This overhauls settings handling within KissMP. Previously, everything was stored inside kissui prepared for imgui widgets. This new solution notifies of changes passively via an extension hook and simplifies access to settings, instead of actively overwriting values from kissconfig directly.
<br>
This also introduces a new config save version. Previously, settings were stored like this:
```json
{"base_secret_v2":" (omitted) ","show_drivers":false,"addr":"","show_nametags":true,"window_opacity":0.80000001192093,"enable_view_distance":false,"name":" (omitted) ","view_distance":300}
```

This was converted to:
```json
{
  "data":{
    "perf.enable_view_distance":true,
    "perf.view_distance":200,
    "players.show_drivers":true,
    "players.show_nametags":true,
    "security.base_secret_v2":" (omitted) ",
    "ui.addr":"127.0.0.1:3690",
    "ui.name":" (omitted) ",
    "ui.window_opacity":0.89999997615814
  },
  "header":{
    "version":2
  }
}
```
Backward compatibility is given using header detection and converting formats if needed. Default values are provided in a separate config file and used by the code as fallback should a new version of KissMP run on an older config.
<br>
In addition to these changes, the settings tab within the main menu was overhauled. Previously, it looked like this:
<img width="436" height="328" alt="grafik" src="https://github.com/user-attachments/assets/4758995d-ef25-4bbe-ad1c-82fb5df046a6" />

This is the new layout:
<img width="664" height="620" alt="image" src="https://github.com/user-attachments/assets/d6a7665f-6791-41eb-8d10-08721f3644ec" />

Now, it also includes settings for server scripts and server mods on public servers (and the associated code for enforcement and server list filtering).

As for names, this fixes positioning to be centered on top of the bounding box, adds fade options, a use-z option and an option to use the player colors on the tag.