### PR TITLE
Electrics/Controller sync improvements

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -201,6 +201,7 @@ local function onExtensionLoaded()
   message_handlers.CouplerAttached = vehiclemanager.attach_coupler
   message_handlers.CouplerDetached = vehiclemanager.detach_coupler
   message_handlers.ElectricsUndefinedUpdate = vehiclemanager.electrics_diff_update
+  message_handlers.ControllersUndefinedUpdate = vehiclemanager.controllers_diff_update
 
   message_handlers.VehicleSetPosition = vehiclemanager.set_position
   message_handlers.VehicleSetPositionRotation = vehiclemanager.set_position_rotation

--- a/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
+++ b/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
@@ -286,7 +286,7 @@ local function onUpdate(dt)
       local vehicle = getObjectByID(i)
       if vehicle and (not kisstransform.inactive[i]) then
         send_vehicle_update(vehicle)
-        vehicle:queueLuaCommand("kiss_electrics.send()")
+        vehicle:queueLuaCommand("kiss_electrics.send(); kiss_controllers.send()")
       end
     end
   end
@@ -441,10 +441,20 @@ local function electrics_diff_update(data)
   if id and not M.ownership[id] then
     local vehicle = getObjectByID(id)
     if not vehicle then return end
-    local data = data[2].diff
     vehicle:queueLuaCommand(string.format(
       "kiss_electrics.apply_diff(%q)",
-      string_buffer.encode(data)))
+      string_buffer.encode(data[2].diff)))
+  end
+end
+
+local function controllers_diff_update(data)
+  local id = M.id_map[data[1] or -1]
+  if id and not M.ownership[id] then
+    local vehicle = getObjectByID(id)
+    if not vehicle then return end
+    vehicle:queueLuaCommand(string.format(
+      "kiss_controllers.apply_diff(%q)",
+      string_buffer.encode(data[2].diff)))
   end
 end
 
@@ -649,6 +659,7 @@ M.onVehicleSwitched = onVehicleSwitched
 M.onMissionLoaded = onMissionLoaded
 M.onFreeroamLoaded = onMissionLoaded
 M.electrics_diff_update = electrics_diff_update
+M.controllers_diff_update = controllers_diff_update
 M.attach_coupler = attach_coupler
 M.detach_coupler = detach_coupler
 M.attach_coupler_inner = attach_coupler_inner

--- a/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
+++ b/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
@@ -182,11 +182,35 @@ local function send_vehicle_config_inner(id, parts_config_json, buffer_data)
   )
 end
 
+local function electrics_diff_update(data)
+  local id = M.id_map[data[1] or -1]
+  if id and not M.ownership[id] then
+    local vehicle = getObjectByID(id)
+    if not vehicle then return end
+    vehicle:queueLuaCommand(string.format(
+      "kiss_electrics.apply_diff(%q)",
+      string_buffer.encode(data[2].diff)))
+  end
+end
+
+local function controllers_diff_update(data)
+  local id = M.id_map[data[1] or -1]
+  if id and not M.ownership[id] then
+    local vehicle = getObjectByID(id)
+    if not vehicle then return end
+    vehicle:queueLuaCommand(string.format(
+      "kiss_controllers.apply_diff(%q)",
+      string_buffer.encode(data[2].diff)))
+  end
+end
+
 local camera_pos = vec3()
 local transform_pos = vec3()
 local view_distance = nil
 
-local function spawn_vehicle(data)
+local function spawn_vehicle(server_data)
+  local data, electrics, controllers = server_data[1], server_data[2], server_data[3]
+
   local model_info = core_vehicles.getModel(data.name)
   if tableSize(model_info) == 0 then
     log("W", "kissmp.vehiclemanager.spawn_vehicle", "Rejected modded vehicle spawn "..data.name)
@@ -208,11 +232,11 @@ local function spawn_vehicle(data)
 
   if M.loading_map or M.delay_spawns then
     log("D", "kissmp.vehiclemanager.spawn_vehicle", "Buffering vehicle")
-    M.vehicle_buffer[data.server_id] = data
+    M.vehicle_buffer[data.server_id] = server_data
     return
   elseif away and view_distance then
     log("D", "kissmp.vehiclemanager.spawn_vehicle", "Buffering vehicle")
-    M.vehicle_buffer[data.server_id] = data
+    M.vehicle_buffer[data.server_id] = server_data
     return
   end
   if data.owner == network.get_client_id() then
@@ -262,6 +286,13 @@ local function spawn_vehicle(data)
   kisstransform.inactive[spawned:getID()] = false
   --if current_vehicle then be:enterVehicle(0, current_vehicle) end
   spawned:queueLuaCommand("extensions.hook('kissUpdateOwnership', false)")
+  if electrics and controllers then
+    spawned:queueLuaCommand(string.format(
+      [[kiss_electrics.apply_diff(%q)
+        kiss_controllers.apply_diff(%q)]],
+      string_buffer.encode(electrics.diff),
+      string_buffer.encode(controllers.diff)))
+  end
 end
 
 local function onUpdate(dt)
@@ -301,12 +332,12 @@ local function onUpdate(dt)
   end
   if not (M.loading_map or M.delay_spawns) then
     local to_remove = {}
-    for k, vehicle in pairs(M.vehicle_buffer) do
+    for k, vehicle_server_data in pairs(M.vehicle_buffer) do
       local t = kisstransform.raw_transforms[k]
       if t then
         transform_pos:set(t.position[1], t.position[2], t.position[3])
         if not (view_distance and transform_pos:squaredDistance(camera_pos) > view_distance) then
-          spawn_vehicle(vehicle)
+          spawn_vehicle(vehicle_server_data)
           table.insert(to_remove, k)
         end
       end
@@ -435,28 +466,6 @@ local function update_vehicle_meta(data)
     extensions.core_vehicle_manager.liveUpdateVehicleColors(id, vehicle, i, table_to_color(ct))
   end
   vehicle:setField('partConfig', '', serialize(vd.config))
-end
-
-local function electrics_diff_update(data)
-  local id = M.id_map[data[1] or -1]
-  if id and not M.ownership[id] then
-    local vehicle = getObjectByID(id)
-    if not vehicle then return end
-    vehicle:queueLuaCommand(string.format(
-      "kiss_electrics.apply_diff(%q)",
-      string_buffer.encode(data[2].diff)))
-  end
-end
-
-local function controllers_diff_update(data)
-  local id = M.id_map[data[1] or -1]
-  if id and not M.ownership[id] then
-    local vehicle = getObjectByID(id)
-    if not vehicle then return end
-    vehicle:queueLuaCommand(string.format(
-      "kiss_controllers.apply_diff(%q)",
-      string_buffer.encode(data[2].diff)))
-  end
 end
 
 local function attach_coupler_inner(buffer_data)

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/4wd.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/4wd.lua
@@ -15,12 +15,10 @@ end
 
 function SyncController:get()
   local data = self.contr and self.contr.serialize()
-  if data then
-    return {
-      data.mode4WD,
-      data.modeRange
-    }
-  end
+  return {
+    data.mode4WD or 0,
+    data.modeRange or 0
+  }
 end
 
 function SyncController:set(data)

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/4wd.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/4wd.lua
@@ -1,0 +1,34 @@
+local SyncController = {}
+SyncController.__index = SyncController
+
+function SyncController.new()
+  local self = setmetatable({}, SyncController)
+  self.contr = nil
+  self.unmapped_data = {}
+  return self
+end
+
+function SyncController:set_controller(value)
+  self.contr = value
+  return self.contr.serialize and self.contr.serialize() ~= nil
+end
+
+function SyncController:get()
+  local data = self.contr and self.contr.serialize()
+  if data then
+    return {
+      data.mode4WD,
+      data.modeRange
+    }
+  end
+end
+
+function SyncController:set(data)
+  self.unmapped_data.mode4WD = data[1]
+  self.unmapped_data.modeRange = data[2]
+  if self.contr then
+    self.contr.deserialize(self.unmapped_data)
+  end
+end
+
+return SyncController

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/antiLag.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/antiLag.lua
@@ -1,0 +1,26 @@
+local SyncController = {}
+SyncController.__index = SyncController
+
+function SyncController.new()
+  local self = setmetatable({}, SyncController)
+  self.contr = nil
+  return self
+end
+
+function SyncController:set_controller(value)
+  self.contr = value
+
+  return true
+end
+
+function SyncController:get()
+  return {
+    electrics.values.alsState or "idle"
+  }
+end
+
+function SyncController:set(data)
+  self.contr.setAntilagState(data[1])
+end
+
+return SyncController

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/braking/compressionBrake.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/braking/compressionBrake.lua
@@ -19,7 +19,6 @@ function SyncController:set_controller(value)
     self.electrics_name_setting = jbeam_controller_data.electricsNameSetting or (engine_name .. "_compressionBrake_setting")
   end
 
-  dump(self.electrics_name_setting)
   return true
 end
 

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/braking/compressionBrake.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/braking/compressionBrake.lua
@@ -1,0 +1,36 @@
+local SyncController = {}
+SyncController.__index = SyncController
+
+function SyncController.new()
+  local self = setmetatable({}, SyncController)
+  self.contr = nil
+
+  self.electrics_name_setting = "mainEngine_compressionBrake_setting"
+  return self
+end
+
+function SyncController:set_controller(value)
+  self.contr = value
+
+  local jbeam_controller_data = v.data.controller[self.contr.name]
+  if jbeam_controller_data then
+    local engine_name = jbeam_controller_data.controlledEngine or "mainEngine"
+
+    self.electrics_name_setting = jbeam_controller_data.electricsNameSetting or (engine_name .. "_compressionBrake_setting")
+  end
+
+  dump(self.electrics_name_setting)
+  return true
+end
+
+function SyncController:get()
+  return {
+    electrics.values[self.electrics_name_setting] or 0
+  }
+end
+
+function SyncController:set(data)
+  self.contr.setCompressionBrakeCoef(data[1])
+end
+
+return SyncController

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/driveModes.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/driveModes.lua
@@ -15,12 +15,10 @@ end
 
 function SyncController:get()
   local data = self.contr and self.contr.serialize()
-  if data then
-    return {
-      data.activeDriveModeKey,
-      data.activeDriveModeIndex
-    }
-  end
+  return {
+    data.activeDriveModeKey or "",
+    data.activeDriveModeIndex or 0
+  }
 end
 
 function SyncController:set(data)

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/driveModes.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/driveModes.lua
@@ -1,0 +1,34 @@
+local SyncController = {}
+SyncController.__index = SyncController
+
+function SyncController.new()
+  local self = setmetatable({}, SyncController)
+  self.contr = nil
+  self.unmapped_data = {}
+  return self
+end
+
+function SyncController:set_controller(value)
+  self.contr = value
+  return self.contr.serialize and self.contr.serialize() ~= nil
+end
+
+function SyncController:get()
+  local data = self.contr and self.contr.serialize()
+  if data then
+    return {
+      data.activeDriveModeKey,
+      data.activeDriveModeIndex
+    }
+  end
+end
+
+function SyncController:set(data)
+  self.unmapped_data.activeDriveModeKey = data[1]
+  self.unmapped_data.activeDriveModeIndex = data[2]
+  if self.contr then
+    self.contr.deserialize(self.unmapped_data)
+  end
+end
+
+return SyncController

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/esc.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/esc.lua
@@ -1,0 +1,32 @@
+local SyncController = {}
+SyncController.__index = SyncController
+
+function SyncController.new()
+  local self = setmetatable({}, SyncController)
+  self.contr = nil
+  self.unmapped_data = {}
+  return self
+end
+
+function SyncController:set_controller(value)
+  self.contr = value
+  return self.contr.serialize and self.contr.serialize() ~= nil
+end
+
+function SyncController:get()
+  local data = self.contr and self.contr.serialize()
+  if data then
+    return {
+      data.escConfigKey,
+    }
+  end
+end
+
+function SyncController:set(data)
+  self.unmapped_data.escConfigKey = data[1]
+  if self.contr then
+    self.contr.deserialize(self.unmapped_data)
+  end
+end
+
+return SyncController

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/esc.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/esc.lua
@@ -15,11 +15,9 @@ end
 
 function SyncController:get()
   local data = self.contr and self.contr.serialize()
-  if data then
-    return {
-      data.escConfigKey,
-    }
-  end
+  return {
+    data.escConfigKey or 0,
+  }
 end
 
 function SyncController:set(data)

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/lineLock.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/lineLock.lua
@@ -1,0 +1,33 @@
+local SyncController = {}
+SyncController.__index = SyncController
+
+function SyncController.new()
+  local self = setmetatable({}, SyncController)
+  self.contr = nil
+
+  self.electrics_name = "linelock"
+  return self
+end
+
+function SyncController:set_controller(value)
+  self.contr = value
+
+  local jbeam_controller_data = v.data.controller[self.contr.name]
+  if jbeam_controller_data then
+    self.electrics_name = jbeam_controller_data.electricsName or "linelock"
+  end
+
+  return true
+end
+
+function SyncController:get()
+  return {
+    electrics.values[self.electrics_name] or 0
+  }
+end
+
+function SyncController:set(data)
+  self.contr.setLineLock(data[1])
+end
+
+return SyncController

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/nitrousOxideInjection.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/nitrousOxideInjection.lua
@@ -1,0 +1,40 @@
+local SyncController = {}
+SyncController.__index = SyncController
+
+function SyncController.new()
+  local self = setmetatable({}, SyncController)
+  self.contr = nil
+
+  self.electrics_arm_name = "nitrousOxideArm"
+  self.override_electrics = "nitrousOxideOverride"
+  return self
+end
+
+function SyncController:set_controller(value)
+  self.contr = value
+
+  local jbeam_controller_data = v.data.controller[self.contr.name]
+  if jbeam_controller_data then
+    self.electrics_arm_name = jbeam_controller_data.electricsArmName or self.electrics_arm_name
+    self.override_electrics = jbeam_controller_data.electricsOverrideName or self.override_electrics
+  end
+
+  return true
+end
+
+function SyncController:get()
+  return {
+    electrics.values[self.electrics_arm_name],
+    electrics.values[self.override_electrics]
+  }
+end
+
+function SyncController:set(data)
+  electrics.values[self.electrics_arm_name] = 1 - data[1]
+  self.contr.toggleActive()
+  if data[2] then
+    self.contr.setOverride(data[2] == 1)
+  end
+end
+
+return SyncController

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/twoStepLaunch.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/twoStepLaunch.lua
@@ -1,0 +1,35 @@
+local SyncController = {}
+SyncController.__index = SyncController
+
+function SyncController.new()
+  local self = setmetatable({}, SyncController)
+  self.contr = nil
+  self.unmapped_data = {}
+  return self
+end
+
+function SyncController:set_controller(value)
+  self.contr = value
+  return self.contr.serialize and self.contr.serialize() ~= nil
+end
+
+function SyncController:get()
+  local data = self.contr and self.contr.serialize()
+  if data then
+    return {
+      data.state,
+      data.rpm
+    }
+  end
+end
+
+function SyncController:set(data)
+  self.unmapped_data.state = data[1]
+  self.unmapped_data.rpm = data[2]
+  if self.contr then
+    self.contr.deserialize(self.unmapped_data)
+    self.contr.setTwoStep(data[1] ~= "deactivated")
+  end
+end
+
+return SyncController

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_controllers.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_controllers.lua
@@ -4,24 +4,29 @@ local string_buffer = require("string.buffer")
 
 local prev_controller_data = {}
 
-local function isDiff(t1, t2)
+local function is_diff(t1, t2)
+  if t1 == t2 then return false end
+
   if type(t1) ~= "table" or type(t2) ~= "table" then
     return t1 ~= t2
   end
 
+  local t1_key_count = 0
   for k, v in pairs(t1) do
-    if type(v) == "table" then
-      if not isDiff(v, t2[k]) then
-        return true
-      end
-    else
-      if v ~= t2[k] then
-        return true
-      end
+    if t2[k] == nil then return true end
+
+    if is_diff(v, t2[k]) then
+      return true
     end
+    t1_key_count = t1_key_count + 1
   end
 
-  return false
+  local t2_key_count = 0
+  for _ in pairs(t2) do
+    t2_key_count = t2_key_count + 1
+  end
+
+  return t1_key_count ~= t2_key_count
 end
 
 local active_controllers = {}
@@ -32,7 +37,7 @@ local function send()
   for i = 1, #active_controllers do
     local new_data = active_controllers[i]:get()
 
-    if isDiff(prev_controller_data[i], new_data) then
+    if is_diff(prev_controller_data[i], new_data) then
       diffs[i] = new_data
       diff_count = diff_count + 1
       prev_controller_data[i] = new_data

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_controllers.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_controllers.lua
@@ -1,0 +1,80 @@
+local M = {}
+
+local string_buffer = require("string.buffer")
+
+local prev_controller_data = {}
+
+local function isDiff(t1, t2)
+  if type(t1) ~= "table" or type(t2) ~= "table" then
+    return t1 ~= t2
+  end
+
+  for k, v in pairs(t1) do
+    if type(v) == "table" then
+      if not isDiff(v, t2[k]) then
+        return true
+      end
+    else
+      if v ~= t2[k] then
+        return true
+      end
+    end
+  end
+
+  return false
+end
+
+local active_controllers = {}
+local function send()
+  local diff_count = 0
+  local diffs = {}
+
+  for i = 1, #active_controllers do
+    local new_data = active_controllers[i]:get()
+
+    if isDiff(prev_controller_data[i], new_data) then
+      diffs[i] = new_data
+      diff_count = diff_count + 1
+      prev_controller_data[i] = new_data
+    end
+  end
+
+  if diff_count > 0 then
+    obj:queueGameEngineLua(string.format(
+      "network.send_data(%q, true)",
+      jsonEncode({
+        ControllersUndefinedUpdate = {objectId, {diff = serialize(diffs)}}
+      })))
+  end
+end
+
+local full_controller_data = {}
+local function apply_diff(buffer_data)
+  local diff = string_buffer.decode(buffer_data)
+  local data = deserialize(diff)
+  for k,v in pairs(data) do
+    tableMergeRecursive(full_controller_data[k], v)
+    active_controllers[k]:set(full_controller_data[k])
+  end
+end
+
+local function onExtensionLoaded()
+  for _, contr in pairs(controller.getAllControllers()) do
+    if FS:fileExists(string.format("/lua/vehicle/extensions/kiss_mp/controller_sync_extensions/%s.lua", contr.typeName)) then
+      -- sync extensions are in this instance format to allow multiple controllers of the same type to be synced
+      local sync_ext = require("/kiss_mp/controller_sync_extensions/"..contr.typeName).new()
+
+      if sync_ext:set_controller(contr) then
+        active_controllers[#active_controllers + 1] = sync_ext
+        full_controller_data[#active_controllers] = sync_ext:get()
+      end
+    end
+  end
+end
+
+M.send = send
+M.apply_diff = apply_diff
+
+M.onExtensionLoaded = onExtensionLoaded
+
+return M

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_controllers.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_controllers.lua
@@ -35,7 +35,7 @@ local function send()
     local new_data = active_controllers[i]:get()
 
     if is_diff(prev_controller_data[i], new_data) then
-      diffs[i] = new_data
+      diffs[tostring(i)] = serialize(new_data)
       diff_count = diff_count + 1
       prev_controller_data[i] = new_data
     end
@@ -45,7 +45,7 @@ local function send()
     obj:queueGameEngineLua(string.format(
       "network.send_data(%q, true)",
       jsonEncode({
-        ControllersUndefinedUpdate = {objectId, {diff = serialize(diffs)}}
+        ControllersUndefinedUpdate = {objectId, {diff = diffs}}
       })))
   end
 end
@@ -53,10 +53,10 @@ end
 local full_controller_data = {}
 local function apply_diff(buffer_data)
   local diff = string_buffer.decode(buffer_data)
-  local data = deserialize(diff)
-  for k,v in pairs(data) do
-    tableMergeRecursive(full_controller_data[k], v)
-    active_controllers[k]:set(full_controller_data[k])
+  for k, v in pairs(diff) do
+    local i = tonumber(k)
+    tableMergeRecursive(full_controller_data[i], deserialize(v))
+    active_controllers[i]:set(full_controller_data[i])
   end
 end
 

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_controllers.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_controllers.lua
@@ -11,22 +11,19 @@ local function is_diff(t1, t2)
     return t1 ~= t2
   end
 
-  local t1_key_count = 0
   for k, v in pairs(t1) do
     if t2[k] == nil then return true end
 
     if is_diff(v, t2[k]) then
       return true
     end
-    t1_key_count = t1_key_count + 1
   end
 
-  local t2_key_count = 0
-  for _ in pairs(t2) do
-    t2_key_count = t2_key_count + 1
+  for k in pairs(t2) do
+    if t1[k] == nil then return true end
   end
 
-  return t1_key_count ~= t2_key_count
+  return false
 end
 
 local active_controllers = {}

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -298,8 +298,14 @@ local function onExtensionLoaded()
         for _, vn in pairs(tableFromHeaderTable(controller_data.couplerNodes)) do
           local cid1 = beamstate.nodeNameMap[vn.cid1]
           local cid2 = beamstate.nodeNameMap[vn.cid2]
-          kiss_couplers.ignore_coupler_node(cid1)
-          kiss_couplers.ignore_coupler_node(cid2)
+
+          if cid1 then
+            kiss_couplers.ignore_coupler_node(cid1)
+          end
+
+          if cid2 then
+            kiss_couplers.ignore_coupler_node(cid2)
+          end
         end
       end
     end

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -3,10 +3,6 @@ local M = {}
 local string_buffer = require("string.buffer")
 
 local prev_electrics = {}
-local prev_signal_electrics = {}
-local last_engine_state = true
-local engine_timer = 0
-local ownership = false
 
 local ignored_keys = {
   throttle = true,
@@ -124,8 +120,6 @@ local ignored_keys = {
   checkengine = true,
 }
 
-local received_data = {}
-
 local electrics_handlers = {
   lights_state = function(v)
     electrics.setLightsState(v)
@@ -191,34 +185,20 @@ local function send()
 end
 
 local function apply_diff_signals(diff)
-  local signal_left_input = diff["signal_left_input"] or prev_signal_electrics["signal_left_input"] or 0
-  local signal_right_input = diff["signal_right_input"] or prev_signal_electrics["signal_right_input"] or 0
-  local hazard_enabled = (signal_left_input > 0.5 and signal_right_input > 0.5)
+  local signal_left_input = diff.signal_left_input or electrics.values.signal_left_input or 0
+  local signal_right_input = diff.signal_right_input or electrics.values.signal_right_input or 0
+  local hazard_enabled = (signal_left_input == 1 and signal_right_input == 1)
 
   if hazard_enabled then
-    electrics.set_warn_signal(1)
+    electrics.set_warn_signal(true)
   else
-    electrics.set_warn_signal(0)
-    if signal_left_input > 0.5 then
-      electrics.toggle_left_signal()
-    elseif signal_right_input > 0.5 then
-      electrics.toggle_right_signal()
-    end
+    electrics.set_warn_signal(false)
+    electrics.set_left_signal(signal_left_input == 1)
+    electrics.set_right_signal(signal_right_input == 1)
   end
 
-  prev_signal_electrics["signal_left_input"] = signal_left_input
-  prev_signal_electrics["signal_right_input"] = signal_right_input
-end
-
-local function set_drive_mode(electric_name, drive_mode_controller, desired_value)
-  -- drive modes only allow applying them by the key, we'll cycle all of them and
-  -- if it's not found it'll return to the previous state
-  local currentDriveMode = drive_mode_controller.getCurrentDriveModeKey()
-  while true do
-    drive_mode_controller.nextDriveMode()
-    if math.abs(electrics.values[electric_name] - desired_value) < 0.1 then break end
-    if drive_mode_controller.getCurrentDriveModeKey() == currentDriveMode then break end
-  end
+  diff.signal_left_input = nil
+  diff.signal_right_input = nil
 end
 
 local function update_advanced_coupler_state(coupler_control_controller, value)
@@ -233,11 +213,11 @@ end
 
 local function apply_diff(buffer_data)
   local diff = string_buffer.decode(buffer_data)
-  apply_diff_signals(diff)
+  if diff.signal_left_input or diff.signal_right_input then
+    apply_diff_signals(diff)
+  end
 
   for k, v in pairs(diff) do
-    received_data[k] = v
-
     local handler = electrics_handlers[k]
     if handler then
       handler(v)
@@ -370,17 +350,10 @@ local function onExtensionLoaded()
   end
 end
 
-local function kissUpdateOwnership(owned)
-  ownership = owned
-end
-
 M.send = send
 M.apply_diff = apply_diff
 M.ignore_key = ignore_key
 
-M.kissUpdateOwnership = kissUpdateOwnership
-
 M.onExtensionLoaded = onExtensionLoaded
-M.updateGFX = updateGFX
 
 return M

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -102,7 +102,9 @@ local ignored_keys = {
   dseRollOverStopped = true,
   dseCrashStopped = true,
   modeRangeBox = true,
-  mode4WD = true
+  mode4WD = true,
+  hasESC = true,
+  hasTCS = true,
 }
 
 local received_data = {}

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -100,7 +100,9 @@ local ignored_keys = {
   dseWarningPulse = true,
   dseRollingOver = true,
   dseRollOverStopped = true,
-  dseCrashStopped = true
+  dseCrashStopped = true,
+  modeRangeBox = true,
+  mode4WD = true
 }
 
 local received_data = {}

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -308,6 +308,16 @@ local function onExtensionLoaded()
   if _G["4ws"] and type(_G["4ws"]) == 'table' then
     ignored_keys["4ws"] = true
   end
+
+  -- Ignore custom JBeam electrics
+  local electrics_jbeam = v.data.electrics or v.data.components.electrics
+  if electrics_jbeam then
+    local jbeamCustomValues = electrics_jbeam.customValues or {}
+    for _, value in ipairs(tableFromHeaderTable(jbeamCustomValues)) do
+      ignored_keys[value.electricsName] = true
+      dump(value.electricsName)
+    end
+  end
 end
 
 local function kissUpdateOwnership(owned)

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -280,6 +280,14 @@ local function onExtensionLoaded()
       elseif controller_data.fileName == "lineLock" then
         -- ignore line lock state
         ignore_key(controller_data.electricsName or "linelock")
+      elseif controller_data.fileName == "braking/compressionBrake" then
+        -- ignore compression brake state
+        local engine_name = controller_data.controlledEngine or "mainEngine"
+
+        ignore_key(controller_data.electricsNameActual or (engine_name .. "_compressionBrake_actual"))
+        ignore_key(controller_data.electricsNameSetting or (engine_name .. "_compressionBrake_setting"))
+        ignore_key(controller_data.electricsNameIsEnabled or (engine_name .. "_compressionBrake_isEnabled"))
+        ignore_key(controller_data.electricsNameLevelIndex or (engine_name .. "_compressionBrake_levelIndex"))
       elseif controller_data.fileName == "advancedCouplerControl" then
         -- register handler for syncing advanced couplers
         local electric = controller_data.name .. "_notAttached"

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -269,6 +269,10 @@ local function onExtensionLoaded()
       elseif controller_data.fileName == "twoStepLaunch" then
         -- ignore two step state
         ignore_key(controller_data.electricsName or "twoStep")
+      elseif controller_data.fileName == "nitrousOxideInjection" then
+        -- ignore nitrous
+        ignore_key(controller_data.electricsArmName or "nitrousOxideArm")
+        ignore_key(controller_data.electricsOverrideName or "nitrousOxideOverride")
       elseif controller_data.fileName == "advancedCouplerControl" then
         -- register handler for syncing advanced couplers
         local electric = controller_data.name .. "_notAttached"

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -315,7 +315,22 @@ local function onExtensionLoaded()
     local jbeamCustomValues = electrics_jbeam.customValues or {}
     for _, value in ipairs(tableFromHeaderTable(jbeamCustomValues)) do
       ignored_keys[value.electricsName] = true
-      dump(value.electricsName)
+    end
+  end
+
+  -- Ignore pneumatic states
+  for k,v in ipairs(controller.getControllersByType("pneumatics/airbrakes")) do
+    ignored_keys[v.name.."_pressure_service"] = true
+    ignored_keys[v.name.."_pressure_parking"] = true
+  end
+
+  for k,v in pairs(energyStorage.getStorages()) do
+    if v.type == "pressureTank" then
+      ignored_keys[v.pressureElectricName] = true
+      ignored_keys[v.pressureConsumerElectricName] = true
+      ignored_keys[v.pressureConsumerCoefElectricName] = true
+      ignored_keys[v.pneumaticPTOConsumerPressureElectricsName] = true
+      ignored_keys[v.pneumaticPTOConsumerFlowElectricsName] = true
     end
   end
 end

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -275,6 +275,9 @@ local function onExtensionLoaded()
         -- ignore nitrous
         ignore_key(controller_data.electricsArmName or "nitrousOxideArm")
         ignore_key(controller_data.electricsOverrideName or "nitrousOxideOverride")
+      elseif controller_data.fileName == "lineLock" then
+        -- ignore line lock state
+        ignore_key(controller_data.electricsName or "linelock")
       elseif controller_data.fileName == "advancedCouplerControl" then
         -- register handler for syncing advanced couplers
         local electric = controller_data.name .. "_notAttached"

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -105,6 +105,8 @@ local ignored_keys = {
   mode4WD = true,
   hasESC = true,
   hasTCS = true,
+  alsActive = true,
+  alsState = true,
 }
 
 local received_data = {}

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -107,6 +107,21 @@ local ignored_keys = {
   hasTCS = true,
   alsActive = true,
   alsState = true,
+  airIntake = true,
+  ignition = true,
+  running = true,
+  electricalLoadCoef = true,
+  nop = true,
+  boostMax = true,
+  turboBoostMax = true,
+  parkingbrakelight = true,
+  brakeGlow_FR = true,
+  brakeGlow_FL = true,
+  brakeGlow_RR = true,
+  brakeGlow_RL = true,
+  minGearIndex = true,
+  maxGearIndex = true,
+  checkengine = true,
 }
 
 local received_data = {}
@@ -125,10 +140,15 @@ local electrics_handlers = {
     electrics.horn(v > 0.5)
   end,
   ignitionLevel = function(v)
+    if v == 2 and electrics.values.ignitionLevel == 3 then
+      -- this means we're currently starting the engine and it's supposed to run
+      return
+    end
     electrics.setIgnitionLevel(v)
   end,
   engineRunning = function(v)
-    if v == 1 and (received_data.ignitionLevel or 2) >= 2 then
+    if v == 1 then
+      electrics.setIgnitionLevel(3)
       controller.mainController.setEngineIgnition(true)
       controller.mainController.setStarter(true)
     end
@@ -217,11 +237,12 @@ local function apply_diff(buffer_data)
 
   for k, v in pairs(diff) do
     received_data[k] = v
-    electrics.values[k] = v
 
     local handler = electrics_handlers[k]
     if handler then
       handler(v)
+    else
+      electrics.values[k] = v
     end
   end
 end

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -128,7 +128,7 @@ local electrics_handlers = {
     electrics.setIgnitionLevel(v)
   end,
   engineRunning = function(v)
-    if v == 1 and received_data.ignitionLevel >= 2 then
+    if v == 1 and (received_data.ignitionLevel or 2) >= 2 then
       controller.mainController.setEngineIgnition(true)
       controller.mainController.setStarter(true)
     end

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -261,22 +261,12 @@ local function onExtensionLoaded()
       elseif controller_data.fileName == "jato" then
         -- ignore jato fuel
         ignore_key("jatofuel")
-      elseif controller_data.fileName == "beaconSpin" and controller_data.electricsName then
+      elseif controller_data.fileName == "beaconSpin" then
         -- ignore beacon spin
-        ignore_key(controller_data.electricsName)
-      elseif controller_data.fileName == "driveModes" and controller_data.modes then
-        -- register handlers for syncing drive modes
-        for _, vm in pairs(controller_data.modes) do
-          if vm.settings then
-            for _, vs in pairs(vm.settings) do
-              if vs[1] == "electricsValue"  then
-                local electric = vs[2].electricsName
-                local drive_mode_controller = controller.getController(controller_data.name)
-                electrics_handlers[electric] = function(v) set_drive_mode(electric, drive_mode_controller, v) end
-              end
-            end
-          end
-        end
+        ignore_key(controller_data.electricsName or "beaconSpin")
+      elseif controller_data.fileName == "twoStepLaunch" then
+        -- ignore two step state
+        ignore_key(controller_data.electricsName or "twoStep")
       elseif controller_data.fileName == "advancedCouplerControl" then
         -- register handler for syncing advanced couplers
         local electric = controller_data.name .. "_notAttached"

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_electrics.lua
@@ -103,29 +103,41 @@ local ignored_keys = {
   dseCrashStopped = true
 }
 
-local electrics_handlers = {}
+local received_data = {}
+
+local electrics_handlers = {
+  lights_state = function(v)
+    electrics.setLightsState(v)
+  end,
+  fog = function(v)
+    electrics.set_fog_lights(v)
+  end,
+  lightbar = function(v)
+    electrics.set_lightbar_signal(v)
+  end,
+  horn = function(v)
+    electrics.horn(v > 0.5)
+  end,
+  ignitionLevel = function(v)
+    electrics.setIgnitionLevel(v)
+  end,
+  engineRunning = function(v)
+    if v == 1 and received_data.ignitionLevel >= 2 then
+      controller.mainController.setEngineIgnition(true)
+      controller.mainController.setStarter(true)
+    end
+  end,
+  hasABS = function(v)
+    if v > 0.5 then
+      wheels.setABSBehavior("realistic")
+    else
+      wheels.setABSBehavior("off")
+    end
+  end
+}
 
 local function ignore_key(key)
   ignored_keys[key] = true
-end
-
-local function update_engine_state()
-  if ownership then return end
-  if not electrics.values.engineRunning then return end
-  local engine_running = electrics.values.engineRunning > 0.5
-
-  -- Trigger starter to swap the engine state
-  if engine_running ~= last_engine_state then
-    controller.mainController.setStarter(true)
-  end
-end
-
-local function updateGFX(dt)
-  engine_timer = engine_timer + dt
-  if engine_timer > 5 then
-    update_engine_state()
-    engine_timer = engine_timer - 5
-  end
 end
 
 local function send()
@@ -196,11 +208,15 @@ end
 local function apply_diff(buffer_data)
   local diff = string_buffer.decode(buffer_data)
   apply_diff_signals(diff)
+
   for k, v in pairs(diff) do
+    received_data[k] = v
     electrics.values[k] = v
 
     local handler = electrics_handlers[k]
-    if handler then handler(v) end
+    if handler then
+      handler(v)
+    end
   end
 end
 
@@ -280,7 +296,7 @@ local function onExtensionLoaded()
 
   -- Ignore commonly used disp_* electrics used on vehicles with gear displays
   for k,v in pairs(electrics.values) do
-    if type(k) == 'string' and k:sub(1,5) == "disp_" then
+    if type(k) == 'string' and k:startswith("disp_") or k:startswith("auto_") then
       ignored_keys[k] = true
     end
   end
@@ -288,24 +304,6 @@ local function onExtensionLoaded()
   -- Ignore common extension/controller electrics
   if _G["4ws"] and type(_G["4ws"]) == 'table' then
     ignored_keys["4ws"] = true
-  end
-
-  -- Register handlers
-  electrics_handlers["lights_state"] = function(v) electrics.setLightsState(v) end
-  electrics_handlers["fog"] = function(v) electrics.set_fog_lights(v) end
-  electrics_handlers["lightbar"] = function(v) electrics.set_lightbar_signal(v) end
-  electrics_handlers["horn"] = function(v) electrics.horn(v > 0.5) end
-  electrics_handlers["hasABS"] = function(v)
-    if v > 0.5 then
-      wheels.setABSBehavior("realistic")
-    else
-      wheels.setABSBehavior("off")
-    end
-  end
-  electrics_handlers["engineRunning"] = function(v) 
-    last_engine_state = v > 0.5
-    update_engine_state()
-    engine_timer = 0
   end
 end
 

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_gearbox.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_gearbox.lua
@@ -11,18 +11,12 @@ local function get_gearbox_data()
   local state = mainController.getState()
   local data = {
     vehicle_id = objectId,
-    lock_coef = gearbox and gearbox.lockCoef or 0,
+    lock_coef = gearbox and gearbox.lockCoef or 1,
+    grb_idx = state.grb_idx ~= nil and state.grb_idx or 0,
+    grb_mde = state.grb_mde ~= nil and state.grb_mde or "",
+    grb_bhv = state.grb_bhv ~= nil and state.grb_bhv or "arcade",
+    frzn = state.frzn ~= nil and state.frzn or false,
   }
-
-  if not state.grb_idx then
-    state.grb_idx = 0
-  end
-
-  if not state.grb_mde then
-    state.grb_mde = ""
-  end
-
-  tableMerge(data, state)
 
   return data
 end

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_gearbox.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_gearbox.lua
@@ -5,126 +5,60 @@ local string_buffer = require("string.buffer")
 local mainController = nil
 local gearbox = nil
 
-local gearbox_is_sequential = false
-local vehicle_is_electric = false
-local gearbox_is_manual = false
-
-local last_requseted_gear = nil
-local sequential_lock = false
-local ownership = false
-local ownership_known = false
-local cooldown_timer = 0
-
-local function set_gear_indices(indices)
-  if mainController and cooldown_timer <= 0 then
-    local index = indices[1]
-    local canShift = true
-
-    -- there's a neutralRejectTimer that will lock sequentials into neutral if we try it more than once
-    -- possibly a game bug
-    if sequential_lock then
-      canShift = false
-    elseif index == 0 and gearbox_is_sequential then
-      sequential_lock = true
-    end
-
-    if canShift then
-      mainController.shiftToGearIndex(index, true) -- true for ignoring sequential bounds
-      last_requseted_gear = index
-    end
-  end
-end
-
-local function get_gear_indices()
-  local index = electrics.values.gearIndex
-
-  -- convert gearIndex to values that shiftToGearIndex accepts
-  if index == nil then index = 0 end
-  if not gearbox_is_sequential and not gearbox_is_manual then
-    if type(electrics.values.gear) == 'string' and string.sub(electrics.values.gear, 1, 1) == 'M' then
-      index = 6 -- M1 is the best we can do
-    elseif electrics.values.gear == "P" then     
-      index = 1 -- park
-    elseif index >= 1 then
-      index = 2 -- drive
-    end
-  end
-
-  return {index, 0}
-end
+local last_received_data = {}
 
 local function get_gearbox_data()
+  local state = mainController.getState()
   local data = {
     vehicle_id = objectId,
     lock_coef = gearbox and gearbox.lockCoef or 0,
-    mode = gearbox and gearbox.mode or "none",
-    gear_indices = get_gear_indices(),
-    arcade = false
   }
+
+  if not state.grb_idx then
+    state.grb_idx = 0
+  end
+
+  if not state.grb_mde then
+    state.grb_mde = ""
+  end
+
+  tableMerge(data, state)
+
   return data
 end
 
 local function apply(buffer_data)
   local data = string_buffer.decode(buffer_data)
-  set_gear_indices(data.gear_indices)
-end
 
-local function updateGFX(dt)
-  if not ownership_known or ownership then return end
-  if cooldown_timer > 0 then
-    cooldown_timer = cooldown_timer - clamp(dt, 0, 0.02)
-    return
+  if last_received_data.grb_mde ~= data.grb_mde or last_received_data.grb_idx ~= data.grb_idx then
+    mainController.setState(data)
   end
-  if sequential_lock and electrics.values.gearIndex == 0 then
-    sequential_lock = false
-  end
-  if gearbox_is_manual and last_requseted_gear ~= 0 and electrics.values.gearIndex == 0 then
-    electrics.values.clutchOverride = 1
-  else
-    electrics.values.clutchOverride = nil
-  end  
-end
 
-local function onReset()
-  cooldown_timer = 0.2
-  sequential_lock = false
+  if gearbox and gearbox.setLock then
+    gearbox:setLock(data.lock_coef == 0)
+  end
+
+  last_received_data = data
 end
 
 local function onExtensionLoaded()
   mainController = controller.mainController
-  vehicle_is_electric = tableSize(powertrain.getDevicesByType("electricMotor")) > 0
   gearbox = powertrain.getDevice("gearbox")
 
   -- Search for a gearbox if one wasn't found
-  if not gearbox and not vehicle_is_electric then
+  if not gearbox then
     local devices = powertrain.getDevices()
     for _, device in pairs(devices) do
-      if device.deviceCategories.gearbox and gearbox == nil then
+      if device.deviceCategories.gearbox then
         gearbox = device
+        break
       end
     end
-  end
-
-  if gearbox then
-    gearbox_is_manual = gearbox.type == "manualGearbox"
-    gearbox_is_sequential = gearbox.type == "sequentialGearbox"
-  end
-end
-
-local function kissUpdateOwnership(owned)
-  ownership = owned
-  ownership_known = true
-  if owned then return end
-  if gearbox and gearbox_is_manual then
-    gearbox.gearDamageThreshold = math.huge
   end
 end
 
 M.apply = apply
 M.get_gearbox_data = get_gearbox_data
 M.onExtensionLoaded = onExtensionLoaded
-M.updateGFX = updateGFX
-M.onReset = onReset
-M.kissUpdateOwnership = kissUpdateOwnership
 
 return M

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_gearbox.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_gearbox.lua
@@ -8,7 +8,7 @@ local gearbox = nil
 local last_received_data = {}
 
 local function get_gearbox_data()
-  local state = mainController.getState()
+  local state = mainController.getState and mainController.getState() or {}
   local data = {
     vehicle_id = objectId,
     lock_coef = gearbox and gearbox.lockCoef or 1,
@@ -24,7 +24,7 @@ end
 local function apply(buffer_data)
   local data = string_buffer.decode(buffer_data)
 
-  if last_received_data.grb_mde ~= data.grb_mde or last_received_data.grb_idx ~= data.grb_idx then
+  if mainController.setState and (last_received_data.grb_mde ~= data.grb_mde or last_received_data.grb_idx ~= data.grb_idx) then
     mainController.setState(data)
   end
 

--- a/kissmp-server/src/events.rs
+++ b/kissmp-server/src/events.rs
@@ -223,7 +223,6 @@ impl Server {
                             if let Some(vehicle) = self.vehicles.get_mut(&server_id) {
                                 if let Some(electrics_undefined) = &mut vehicle.electrics_undefined {
                                     for (key, value) in &undefined_update.diff {
-                                        info!("Electrics updated! <{}>", key.clone());
                                         electrics_undefined.diff.insert(key.clone(), *value);
                                     }
                                 }

--- a/kissmp-server/src/events.rs
+++ b/kissmp-server/src/events.rs
@@ -225,6 +225,28 @@ impl Server {
                             }
                         }
                     }
+                    ControllersUndefinedUpdate(vehicle_id, undefined_update) => {
+                        if let Some(server_id) =
+                            self.get_server_id_from_game_id(client_id, vehicle_id)
+                        {
+                            /* if let Some(vehicle) = self.vehicles.get_mut(&server_id) {
+                                for (key, value) in &undefined_update.diff {
+                                    if let Some(electrics) = &mut vehicle.electrics {
+                                        electrics.undefined.insert(key.clone(), *value);
+                                    }
+                                }
+                            }*/
+                            for (_, client) in &mut self.connections {
+                                let _ = client
+                                    .ordered
+                                    .send(ServerCommand::ControllersUndefinedUpdate(
+                                        server_id,
+                                        undefined_update.clone(),
+                                    ))
+                                    .await;
+                            }
+                        }
+                    }
                     Ping(ping) => {
                         let connection = self.connections.get_mut(&client_id).unwrap();
                         connection.client_info_public.ping = ping as u32;

--- a/kissmp-server/src/events.rs
+++ b/kissmp-server/src/events.rs
@@ -50,7 +50,7 @@ impl Server {
                 for (_, vehicle) in &self.vehicles {
                     let _ = connection
                         .ordered
-                        .send(ServerCommand::VehicleSpawn(vehicle.data.clone()))
+                        .send(ServerCommand::VehicleSpawn(vehicle.data.clone(), vehicle.electrics_undefined.clone(), vehicle.controller_undefined.clone()))
                         .await;
                 }
                 for info in client_info_list {
@@ -219,13 +219,15 @@ impl Server {
                         if let Some(server_id) =
                             self.get_server_id_from_game_id(client_id, vehicle_id)
                         {
-                            /* if let Some(vehicle) = self.vehicles.get_mut(&server_id) {
-                                for (key, value) in &undefined_update.diff {
-                                    if let Some(electrics) = &mut vehicle.electrics {
-                                        electrics.undefined.insert(key.clone(), *value);
+                            // Server-side caching
+                            if let Some(vehicle) = self.vehicles.get_mut(&server_id) {
+                                if let Some(electrics_undefined) = &mut vehicle.electrics_undefined {
+                                    for (key, value) in &undefined_update.diff {
+                                        info!("Electrics updated! <{}>", key.clone());
+                                        electrics_undefined.diff.insert(key.clone(), *value);
                                     }
                                 }
-                            }*/
+                            }
                             for (_, client) in &mut self.connections {
                                 let _ = client
                                     .ordered
@@ -241,13 +243,14 @@ impl Server {
                         if let Some(server_id) =
                             self.get_server_id_from_game_id(client_id, vehicle_id)
                         {
-                            /* if let Some(vehicle) = self.vehicles.get_mut(&server_id) {
-                                for (key, value) in &undefined_update.diff {
-                                    if let Some(electrics) = &mut vehicle.electrics {
-                                        electrics.undefined.insert(key.clone(), *value);
+                            // Server-side caching
+                            if let Some(vehicle) = self.vehicles.get_mut(&server_id) {
+                                if let Some(controller_undefined) = &mut vehicle.controller_undefined {
+                                    for (key, value) in &undefined_update.diff {
+                                        controller_undefined.diff.insert(key.clone(), value.clone());
                                     }
                                 }
-                            }*/
+                            }
                             for (_, client) in &mut self.connections {
                                 let _ = client
                                     .ordered

--- a/kissmp-server/src/server_vehicle.rs
+++ b/kissmp-server/src/server_vehicle.rs
@@ -6,6 +6,8 @@ pub struct Vehicle {
     pub electrics: Option<Electrics>,
     pub gearbox: Option<Gearbox>,
     pub data: VehicleData,
+    pub electrics_undefined: Option<ElectricsUndefined>,
+    pub controller_undefined: Option<ControllerUndefined>,
 }
 
 impl crate::Server {
@@ -93,10 +95,23 @@ impl crate::Server {
         let mut data = data.clone();
         data.server_id = server_id;
         data.owner = owner;
+        let vehicle = Vehicle {
+            data,
+            gearbox: None,
+            electrics: None,
+            transform: None,
+            electrics_undefined: Some(ElectricsUndefined {
+                diff: HashMap::new(),
+            }),
+            controller_undefined: Some(ControllerUndefined {
+                diff: HashMap::new(),
+            }),
+        };
+
         for (_, client) in &mut self.connections {
             let _ = client
                 .ordered
-                .send(ServerCommand::VehicleSpawn(data.clone()))
+                .send(ServerCommand::VehicleSpawn(vehicle.data.clone(), vehicle.electrics_undefined.clone(), vehicle.controller_undefined.clone()))
                 .await;
         }
         if let Some(owner) = owner {
@@ -107,16 +122,11 @@ impl crate::Server {
             self.vehicle_ids
                 .get_mut(&owner)
                 .unwrap()
-                .insert(data.in_game_id, server_id);
+                .insert(vehicle.data.in_game_id, server_id);
         }
         self.vehicles.insert(
             server_id,
-            Vehicle {
-                data,
-                gearbox: None,
-                electrics: None,
-                transform: None,
-            },
+            vehicle,
         );
 
         let _ = self.update_lua_vehicles();

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -93,7 +93,7 @@ pub enum ClientCommand {
     CouplerAttached(CouplerAttached),
     CouplerDetached(CouplerDetached),
     ElectricsUndefinedUpdate(u32, ElectricsUndefined),
-    ControllersUndefinedUpdate(u32, SerializedUndefined),
+    ControllersUndefinedUpdate(u32, ControllerUndefined),
     VoiceChatPacket(Vec<u8>),
     // Only used by bridge
     SpatialUpdate([f32; 3], [f32; 3]),
@@ -112,7 +112,7 @@ pub enum ClientCommand {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ServerCommand {
     VehicleUpdate(VehicleUpdate),
-    VehicleSpawn(VehicleData),
+    VehicleSpawn(VehicleData, Option<ElectricsUndefined>, Option<ControllerUndefined>),
     RemoveVehicle(u32),
     ResetVehicle(VehicleReset),
     Chat(String, Option<u32>),
@@ -125,7 +125,7 @@ pub enum ServerCommand {
     CouplerAttached(CouplerAttached),
     CouplerDetached(CouplerDetached),
     ElectricsUndefinedUpdate(u32, ElectricsUndefined),
-    ControllersUndefinedUpdate(u32, SerializedUndefined),
+    ControllersUndefinedUpdate(u32, ControllerUndefined),
     ServerInfo(ServerInfo),
     FilePart(String, Vec<u8>, u32, u32, u32),
     VoiceChatPacket(u32, [f32; 3], Vec<u8>),

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -90,6 +90,7 @@ pub enum ClientCommand {
     CouplerAttached(CouplerAttached),
     CouplerDetached(CouplerDetached),
     ElectricsUndefinedUpdate(u32, ElectricsUndefined),
+    ControllersUndefinedUpdate(u32, SerializedUndefined),
     VoiceChatPacket(Vec<u8>),
     // Only used by bridge
     SpatialUpdate([f32; 3], [f32; 3]),
@@ -121,6 +122,7 @@ pub enum ServerCommand {
     CouplerAttached(CouplerAttached),
     CouplerDetached(CouplerDetached),
     ElectricsUndefinedUpdate(u32, ElectricsUndefined),
+    ControllersUndefinedUpdate(u32, SerializedUndefined),
     ServerInfo(ServerInfo),
     FilePart(String, Vec<u8>, u32, u32, u32),
     VoiceChatPacket(u32, [f32; 3], Vec<u8>),

--- a/shared/src/vehicle/electrics.rs
+++ b/shared/src/vehicle/electrics.rs
@@ -6,6 +6,11 @@ pub struct ElectricsUndefined {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct SerializedUndefined {
+    pub diff: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Electrics {
     pub throttle_input: f32,
     pub brake_input: f32,

--- a/shared/src/vehicle/electrics.rs
+++ b/shared/src/vehicle/electrics.rs
@@ -6,8 +6,8 @@ pub struct ElectricsUndefined {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct SerializedUndefined {
-    pub diff: String,
+pub struct ControllerUndefined {
+    pub diff: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/shared/src/vehicle/gearbox.rs
+++ b/shared/src/vehicle/gearbox.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Gearbox {
-    pub arcade: bool,
     pub lock_coef: f32,
-    pub mode: Option<String>,
-    pub gear_indices: [i8; 2],
+    pub grb_bhv: Option<String>,
+    pub grb_idx: i8,
+    pub grb_mde: Option<String>,
+    pub frzn: bool,
 }


### PR DESCRIPTION
This PR includes a bunch of improvements and additions to existing sync code. See #184 
Note: server and bridge _need_ to be rebuilt. This adds a new struct and changes the gearbox struct.

## What was changed
- Gears
Gear sync was very rudimentary and hardcoded. This now uses getState and setState of the vehicleController
- Electrics
Ignition level is now properly synced (off -> accessories -> ignition -> starter)
Vehicle specific electrics are ignored
More state values are ignored
- Controller syncing
Explicit sync for these common controllers: brake line lock, 4wd, two step, nos, driveModes (and old esc), anti lag, compression brake

## What is to be done
- Break Groups
- energyStorage/Powertrain Damage
- Pressure Wheel data
- Hydraulics
- Pneumatics