### PR TITLE
Prevent client duplication

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/kissplayers.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissplayers.lua
@@ -181,6 +181,8 @@ local function update_player_head(dt, player_id, vehicle)
 end
 
 local function update_players(_, dt_sim)
+  if vehiclemanager and vehiclemanager.loading_map then return end
+
   update_unicycle_replacements(dt_sim)
 
   camera_pos:set(core_camera.getPositionXYZ())

--- a/KISSMultiplayer/lua/ge/extensions/kisstransform.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kisstransform.lua
@@ -18,6 +18,7 @@ local transform_pos = vec3()
 local camera_pos = vec3()
 local function update(dt)
   if not network.connection.connected then return end
+  if vehiclemanager and vehiclemanager.loading_map then return end
   -- Get rotation/angular velocity from vehicle lua
   for vid, v in vehiclesIterator() do
     if not M.inactive[vid] then

--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -286,7 +286,11 @@ local function connect(addr, player_name, is_public)
 
   if M.connection.connected then
     disconnect()
+  elseif M.connection.tcp then
+    M.connection.tcp:close()
+    M.connection.tcp = nil
   end
+
   M.players = {}
   M.download_start_time = 0
   M.download_queue = {}
@@ -298,7 +302,7 @@ local function connect(addr, player_name, is_public)
   kissui.chat.add_message("Connecting to "..addr.."...")
   M.connection.tcp = socket.tcp()
   M.connection.tcp:settimeout(3.0)
-  local connected, err = M.connection.tcp:connect("127.0.0.1", "7894")
+  M.connection.tcp:connect("127.0.0.1", "7894")
 
   -- Send server address to the bridge
   local addr_lenght = ffi.string(ffi.new("uint32_t[?]", 1, {#addr}), 4)
@@ -321,7 +325,6 @@ local function connect(addr, player_name, is_public)
 
   local len, _, _ = M.connection.tcp:receive(4)
   len = bytesToU32(len)
-
   local received, _, _ = M.connection.tcp:receive(len)
   local server_info = jsonDecode(received).ServerInfo
   if not server_info then
@@ -432,8 +435,13 @@ local function onUpdate(dt)
   local max_packets_per_update = 64
 
   while packets_processed < max_packets_per_update do
-    local msg_type = M.connection.tcp:receive(1)
-    if not msg_type then break end
+    local msg_type, err = M.connection.tcp:receive(1)
+    if not msg_type then
+      if err == "closed" then
+        disconnect("Connection lost")
+      end
+      break
+    end
     packets_processed = packets_processed + 1
 
     M.connection.tcp:settimeout(5.0)

--- a/KISSMultiplayer/lua/ge/extensions/network.lua
+++ b/KISSMultiplayer/lua/ge/extensions/network.lua
@@ -96,6 +96,12 @@ local function disconnect(data)
   end
   kissui.chat.add_message(text)
   M.connection.connected = false
+  
+  if vehiclemanager then
+    vehiclemanager.loading_map = false
+  end
+  kissui.show_download = false
+
   if M.connection.tcp then
     M.connection.tcp:close()
     M.connection.tcp = nil
@@ -103,13 +109,13 @@ local function disconnect(data)
 
   cancel_download()
 
-  -- Delete the 3D player models from world memory
-  for _, v in pairs(kissplayers.players) do
-    if v then v:delete() end
-  end
-  for _, v in pairs(kissplayers.players_in_cars) do
-    if v then v:delete() end
-  end
+  -- -- Delete the 3D player models from world memory
+  -- for _, v in pairs(kissplayers.players) do
+  --   if v then v:delete() end
+  -- end
+  -- for _, v in pairs(kissplayers.players_in_cars) do
+  --   if v then v:delete() end
+  -- end
 
   M.players = {}
   kissplayers.players = {}
@@ -180,6 +186,13 @@ local function handle_player_disconnected(data)
   if kissplayers.players_in_cars[id] then
     kissplayers.delete_player_head(id)
   end
+
+  -- Delete the 3D player models from world memory
+  if kissplayers.players[id] then
+    kissplayers.players[id]:delete()
+    kissplayers.players[id] = nil
+  end
+  kissplayers.player_transforms[id] = nil
 end
 
 local function handle_chat(data)

--- a/kissmp-bridge/src/main.rs
+++ b/kissmp-bridge/src/main.rs
@@ -114,7 +114,6 @@ async fn connect_to_server(
         
         let mut transport = quinn::TransportConfig::default();
         transport.max_idle_timeout(Some(IdleTimeout::try_from(SERVER_IDLE_TIMEOUT).unwrap()));
-        transport.keep_alive_interval(Some(std::time::Duration::from_secs(2)));
 
         // settings for VPN like Hamachi
         transport.initial_mtu(1200);
@@ -143,30 +142,6 @@ async fn connect_to_server(
             return;
         }
     };
-
-    // Send initial client info to establish connection
-    let client_info = shared::ClientCommand::ClientInfo(shared::ClientInfoPrivate {
-        name: "Bridge Client".to_string(),
-        client_version: shared::VERSION,
-        secret: String::from("bridge"),
-        steamid64: None,
-    });
-
-    let client_info_data = bincode::serialize(&client_info).unwrap();
-
-    // Send client info through reliable stream
-    let mut send_stream = match server_connection.open_uni().await {
-        Ok(stream) => stream,
-        Err(e) => {
-            error!("Failed to open send stream: {}", e);
-            return;
-        }
-    };
-
-    if let Err(e) = send(&mut send_stream, &client_info_data).await {
-        error!("Failed to send client info: {}", e);
-        return;
-    }
 
     // Wait for server info response
     let mut stream = match server_connection.accept_uni().await {

--- a/kissmp-server/src/events.rs
+++ b/kissmp-server/src/events.rs
@@ -7,6 +7,25 @@ impl Server {
         match event {
             ClientConnected(connection) => {
                 let player_name = connection.client_info_public.name.clone();
+
+                let secret = connection.client_info_private.secret.clone();
+
+                // Kick ghost IDs to prevent client duplication
+                let ghost_id = self.connections.iter()
+                    .find(|(_, c)| c.client_info_private.secret == secret)
+                    .map(|(&id, _)| id);
+
+                if let Some(id) = ghost_id {
+                    if let Some(ghost) = self.connections.remove(&id) {
+                        ghost.conn.close(0u32.into(), b"Reconnected");
+                    }
+                    if let Some(client_vehicles) = self.vehicle_ids.get(&id).cloned() {
+                        for (_, vid) in client_vehicles {
+                            self.remove_vehicle(vid, Some(id)).await;
+                        }
+                    }
+                }
+
                 self.connections.insert(client_id, connection);
                 // Kinda ugly, but idk how to deal with lifetimes otherwise
                 let mut client_info_list = vec![];

--- a/kissmp-server/src/events.rs
+++ b/kissmp-server/src/events.rs
@@ -16,13 +16,19 @@ impl Server {
                     .map(|(&id, _)| id);
 
                 if let Some(id) = ghost_id {
+                    // Remove ghost and drop the connection
                     if let Some(ghost) = self.connections.remove(&id) {
                         ghost.conn.close(0u32.into(), b"Reconnected");
                     }
+                    // Remove ghost vehicles
                     if let Some(client_vehicles) = self.vehicle_ids.get(&id).cloned() {
                         for (_, vid) in client_vehicles {
                             self.remove_vehicle(vid, Some(id)).await;
                         }
+                    }
+                    // Tell remaining clients to delete ghost's nametag/list entry
+                    for (_, client) in &mut self.connections {
+                        let _ = client.ordered.send(ServerCommand::PlayerDisconnected(id)).await;
                     }
                 }
 
@@ -68,42 +74,29 @@ impl Server {
                 });
             }
             ConnectionLost => {
-                let player_name = self
-                    .connections
-                    .get(&client_id)
-                    .unwrap()
-                    .client_info_public
-                    .name
-                    .clone();
-                self.connections
-                    .get_mut(&client_id)
-                    .unwrap()
-                    .conn
-                    .close(0u32.into(), b"");
-                self.connections.remove(&client_id);
-                if let Some(client_vehicles) = self.vehicle_ids.clone().get(&client_id) {
-                    for (_, id) in client_vehicles {
-                        self.remove_vehicle(*id, Some(client_id)).await;
+                if let Some(client) = self.connections.remove(&client_id) {
+                    let player_name = client.client_info_public.name.clone();
+                    client.conn.close(0u32.into(), b"");
+                    
+                    if let Some(client_vehicles) = self.vehicle_ids.clone().get(&client_id) {
+                        for (_, id) in client_vehicles {
+                            self.remove_vehicle(*id, Some(client_id)).await;
+                        }
                     }
+                    for (_, c) in &mut self.connections {
+                        c.send_chat_message(format!("Player {} has left the server", player_name)).await;
+                        let _ = c.ordered.send(ServerCommand::PlayerDisconnected(client_id)).await;
+                    }
+                    let _ = self.update_lua_connections();
+                    self.lua.context(|lua_ctx| {
+                        let _ = crate::lua::run_hook::<u32, ()>(
+                            lua_ctx,
+                            String::from("OnPlayerDisconnected"),
+                            client_id,
+                        );
+                    });
+                    info!("Client has disconnected from the server");
                 }
-                for (_, client) in &mut self.connections {
-                    client
-                        .send_chat_message(format!("Player {} has left the server", player_name))
-                        .await;
-                    let _ = client
-                        .ordered
-                        .send(ServerCommand::PlayerDisconnected(client_id))
-                        .await;
-                }
-                let _ = self.update_lua_connections();
-                self.lua.context(|lua_ctx| {
-                    let _ = crate::lua::run_hook::<u32, ()>(
-                        lua_ctx,
-                        String::from("OnPlayerDisconnected"),
-                        client_id,
-                    );
-                });
-                info!("Client has disconnected from the server");
             }
             ClientCommand(command) => {
                 match command {

--- a/kissmp-server/src/lib.rs
+++ b/kissmp-server/src/lib.rs
@@ -175,9 +175,8 @@ impl Server {
 
         let mut transport = quinn::TransportConfig::default();
         transport.max_idle_timeout(Some(
-            IdleTimeout::try_from(std::time::Duration::from_secs(60)).unwrap(),
+            IdleTimeout::try_from(std::time::Duration::from_secs(10)).unwrap(),
         ));
-        transport.keep_alive_interval(Some(std::time::Duration::from_secs(2)));
 
         // settings for VPN like Hamachi
         transport.initial_mtu(1200);
@@ -306,23 +305,6 @@ impl Server {
         debug!("Connection handshake starting...");
         debug!("Connection stats: {:?}", connection.stats());
 
-        // timeout for receiving client info
-        let _client_info = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            async {
-                let mut stream = connection.accept_uni().await?;
-                debug!("Receiving client info stream...");
-                let mut buf = [0; 4];
-                stream.read_exact(&mut buf[0..4]).await?;
-                let len = u32::from_le_bytes(buf).min(16384) as usize;
-                debug!("Expected client info length: {}", len);
-                let mut buf: Vec<u8> = vec![0; len];
-                stream.read_exact(&mut buf).await?;
-                debug!("Received client info bytes: {} bytes", buf.len());
-                Ok::<_, anyhow::Error>(buf)
-            }
-        ).await;
-
         if self.connections.len() >= self.max_players.into() {
             connection.close(0u32.into(), b"Server is full");
             return Err(anyhow::Error::msg("Server is full"));
@@ -405,17 +387,15 @@ impl Server {
                 .await
                 .unwrap();
             debug!("[CONNECT_TASK] Starting drive_receive for {}", id);
-            if let Err(_e) = Self::drive_receive(
+            let _ = Self::drive_receive(
                 id,
                 connection_clone.clone(),
                 client_events_tx.clone(),
             )
-            .await
-            {
-                let _ = client_events_tx
-                    .send((id, IncomingEvent::ConnectionLost))
-                    .await;
-            }
+            .await;
+            let _ = client_events_tx
+                .send((id, IncomingEvent::ConnectionLost))
+                .await;
         });
 
         let server_info =


### PR DESCRIPTION
Closes #205. In summary, this fixes client connection duplication, prevents TCP connection leaks and catches more errors server-side and locally.

## Changelist:

### Backend (Rust)
- Removal of debugging logic used for early 0.7 testing (I forgot to remove this)
  - was previously testing by making initial handshake with a mock "Bridge Client", now removed
  - removal of transport.keep_alive_interval for bridge and server which would constantly ping to keep connections alive ( was also used during testing, and would prevent timeouts from happening)
 - `events.rs` ghost client logic
   - preventing client duplication "ghosts" if client attempts fast reconnects before their initial connections are timed out
   - `ConnectionLost` changes: catching some errors to prevent server crashing upon trying to remove players after their ghosts are removed.
 - `drive_receive` in server `lib.rs`: make sure ghosts are removed

### Client (Lua)
- moving deletion of player model to `handle_player_disconnected` from `disconnect`
- added update error checks to prevent exceptions when client attempts to connect to a server they are already connected to