### PR TITLE
Whitelist http url to prevent SSRF in http_proxy

### DIFF
--- a/kissmp-bridge/Cargo.toml
+++ b/kissmp-bridge/Cargo.toml
@@ -21,7 +21,7 @@ rustls = { version = "0.21", features = ["dangerous_configuration"] }
 webpki = "0.21"
 anyhow = "1.0.32"
 reqwest = { version = "0.11", default-features = false, features=["rustls-tls"] }
-tiny_http="0.8"
+tiny_http="0.12"
 tokio-stream="0.1.18"
 tokio = { version = "1.51", features = ["time", "macros", "sync", "io-util", "net"] }
 discord-rpc-client = {version = "0.4", optional = true}

--- a/kissmp-bridge/src/http_proxy.rs
+++ b/kissmp-bridge/src/http_proxy.rs
@@ -28,8 +28,8 @@ pub async fn spawn_http_proxy(discord_tx: std::sync::mpsc::Sender<crate::Discord
             continue;
         }
         let mut url = request.url().to_string();
-        //println!("{:?}", url);
         url.remove(0);
+        let url = url.replace("http:/", "http://").replace("https:/", "https://");
         if url == "check" {
             let response = tiny_http::Response::from_string("ok");
             request.respond(response).unwrap();
@@ -86,7 +86,8 @@ pub async fn spawn_http_proxy(discord_tx: std::sync::mpsc::Sender<crate::Discord
             continue;
         }
         // Prevent unrestricted internet/local network access (SSRF)
-        if !url.starts_with("http://kissmp.thehellbox.ru") && !url.starts_with("https://kissmp.thehellbox.ru") {
+        if !url.starts_with(&format!("http://{}", shared::MASTER_SERVER)) 
+            && !url.starts_with(&format!("https://{}", shared::MASTER_SERVER)) {
             let response = tiny_http::Response::from_string("[]");
             let _ = request.respond(response);
             continue;

--- a/kissmp-bridge/src/http_proxy.rs
+++ b/kissmp-bridge/src/http_proxy.rs
@@ -23,7 +23,7 @@ pub async fn spawn_http_proxy(discord_tx: std::sync::mpsc::Sender<crate::Discord
             Ok(Ok(req)) => req,
             _ => continue,
         };
-        let addr = request.remote_addr();
+        let addr = request.remote_addr().unwrap();
         if addr.ip() != Ipv4Addr::new(127, 0, 0, 1) {
             continue;
         }

--- a/kissmp-bridge/src/http_proxy.rs
+++ b/kissmp-bridge/src/http_proxy.rs
@@ -85,6 +85,12 @@ pub async fn spawn_http_proxy(discord_tx: std::sync::mpsc::Sender<crate::Discord
             request.respond(response).unwrap();
             continue;
         }
+        // Prevent unrestricted internet/local network access (SSRF)
+        if !url.starts_with("http://kissmp.thehellbox.ru") && !url.starts_with("https://kissmp.thehellbox.ru") {
+            let response = tiny_http::Response::from_string("[]");
+            let _ = request.respond(response);
+            continue;
+        }
         // Timeout so a dead master server domain doesn't hang the game indefinitely
         if let Ok(Ok(response)) = tokio::time::timeout(
             std::time::Duration::from_secs(5),

--- a/kissmp-server/src/lib.rs
+++ b/kissmp-server/src/lib.rs
@@ -135,7 +135,7 @@ impl Server {
                 self.upnp_port = Some(port);
                 info!("Fetching public IP address...");
                 let socket = UdpSocket::bind(&addr).unwrap();
-                let _ = socket.connect("kissmp.thehellbox.ru:3691");
+                let _ = socket.connect(format!("{}:3691", shared::MASTER_SERVER));
                 let mut i = 0;
                 while i < 5 {
                     let _ = socket.send(b"hi");
@@ -288,7 +288,7 @@ impl Server {
         let client = self.reqwest_client.clone();
         tokio::spawn(async move {
             let _ = client
-                .post("http://kissmp.thehellbox.ru:3692")
+                .post(format!("http://{}:3692", shared::MASTER_SERVER))
                 .body(server_info)
                 .send()
                 .await;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -24,6 +24,8 @@ pub const VERSION: (u32, u32) = (
     parse_env_u32(env!("CARGO_PKG_VERSION_MINOR"))
 );
 
+pub const MASTER_SERVER: &str = "kissmp.thehellbox.ru";
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ClientInfoPrivate {
     pub name: String,


### PR DESCRIPTION
Closes #207. Strict whitelist for master server domain.

Before:
<img width="568" height="59" alt="image" src="https://github.com/user-attachments/assets/2ac07062-97d1-44de-a561-1e4fd4384e50" />

After:
<img width="469" height="39" alt="image" src="https://github.com/user-attachments/assets/3bdc3895-af2c-486e-87f0-b96a7290ff2a" />
