### PR TITLE
Fix "cannot change a protected metatable" when reloading kissconfig

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/kissconfig.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissconfig.lua
@@ -97,6 +97,7 @@ local function load_config()
     config["security.base_secret_v2"] = generate_base_secret()
   end
 
+  magic_config = {}
   local mt = {
     __index = function(_, key)
       return get_setting(key)


### PR DESCRIPTION
This won't affect players, but it is likely to cause headaches during development later on.