### PR TITLE
fix(chatui): remove redundant PopItemWidth call

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/kissmp/ui/chat.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/ui/chat.lua
@@ -141,7 +141,6 @@ local function draw()
     if imgui.Button("Send", imgui.ImVec2(button_width, -1)) then
       send_current_chat_message()
     end
-    imgui.PopItemWidth()
   end
   imgui.End()
   imgui.PopStyleVar()


### PR DESCRIPTION
Fix for the error message on the chat UI:
<img width="748" height="437" alt="image" src="https://github.com/user-attachments/assets/e8b26c97-0b7f-43c0-b4cf-67a8c06b799c" />

