### PR TITLE
fix(unicylce cleanup): defer cleanup until vehicle callbacks complete

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/kissmp/vehiclemanager.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmp/vehiclemanager.lua
@@ -8,6 +8,7 @@ local meta_timer = 0
 local colors_buffer = {}
 local plates_buffer = {}
 local first_vehicle = true
+local pending_unicycle_cleanup = {}
 
 M.id_map = {}
 M.server_ids = {}
@@ -293,8 +294,30 @@ local function spawn_vehicle(server_data)
   end
 end
 
+local function queue_unicycle_cleanup(except_id)
+  for vid, vehicle in vehiclesIterator() do
+    if vehicle:getJBeamFilename() == "unicycle" and vid ~= except_id then
+      -- Defer deletion until the current vehicle callback has returned. The
+      -- walking extension can still use its old vehicle reference at that point.
+      pending_unicycle_cleanup[vid] = true
+    end
+  end
+end
+
+local function cleanup_pending_unicycles()
+  for id in pairs(pending_unicycle_cleanup) do
+    local vehicle = getObjectByID(id)
+    if vehicle and vehicle:getJBeamFilename() == "unicycle" then
+      vehicle:delete()
+    end
+    pending_unicycle_cleanup[id] = nil
+  end
+end
+
 local function onUpdate(dt)
   camera_pos:set(core_camera.getPositionXYZ())
+
+  cleanup_pending_unicycles()
 
   -- Track color and plate changes
   meta_timer = meta_timer + dt
@@ -579,11 +602,7 @@ local function onVehicleSpawned(id)
   send_vehicle_config(id)
   -- Attempt to workaround a bug from latest beamng update. Also prevents unicycle cloning(Somewhat)
   if vehicle:getJBeamFilename() == "unicycle" then
-    for vid, v in vehiclesIterator() do
-      if v:getJBeamFilename() == "unicycle" and vid ~= vehicle:getID() then
-        v:delete()
-      end
-    end
+    queue_unicycle_cleanup(vehicle:getID())
   end
 end
 
@@ -616,11 +635,7 @@ local function onVehicleResetted(id)
 end
 
 local function onVehicleSwitched(_id, new_id)
-  for vid, v in vehiclesIterator() do
-    if v:getJBeamFilename() == "unicycle" and vid ~= new_id then
-      v:delete()
-    end
-  end
+  queue_unicycle_cleanup(new_id)
   if M.ownership[new_id] then
     kissmp_network.send_data(
       {


### PR DESCRIPTION
Fixes #218.

Basically, when walking mode exits, `walk.lua` does this:

```lua
local unicycle = getCurrentUnicycle()
be:enterVehicle(0, vehicle)
unicycleId = unicycle:getId()
```

The multiplayer vehicle manager then loops through all vehicles and deletes every unicycle whose ID is not `new_id`.

`walk.lua` still had the Lua variable referring to the old unicycle and called:

   ```lua
   unicycle:getId()
   ```

The Lua variable still existed, but the underlying BeamNG vehicle object had already been destroyed. That produced the invalid userdata error.

The fix moves the deletion to the next update tick so that the game doesn't call non-existent objects.

Tested it on a few new restarts of the game and mod and it did not happen anymore. :)

<details>
<summary>Errors:</summary>
<img width="615" height="369" alt="image" src="https://github.com/user-attachments/assets/073dcbda-012d-4714-bbe4-719eb83a2f92" />
<img width="1504" height="870" alt="image" src="https://github.com/user-attachments/assets/4d9307e4-e1f8-416d-9d98-9569ad7af4d9" />

